### PR TITLE
Update current project version with meeds version

### DIFF
--- a/services/plf-community-edition-service/src/main/resources/conf/platform.properties
+++ b/services/plf-community-edition-service/src/main/resources/conf/platform.properties
@@ -2,10 +2,10 @@
 product.groupId=org.exoplatform.platform
 product.buildNumber=@timestamp@
 product.revision=@buildNumber@
-product.version=@org.exoplatform.social.version@
+product.version=@project.version@
 
 # If your product don't use one of those products, please comment it
 org.exoplatform.social=@org.exoplatform.social.version@
 
-# Current project's version
-org.exoplatform.platform=@project.version@
+# Platform version
+org.exoplatform.platform=@org.exoplatform.social.version@


### PR DESCRIPTION
${product.version} is used by addons-manager to determine the bundle version.
while ${org.exoplatform.platform} is used for upgrade.