### PR TITLE
Delete useless portlet filter

### DIFF
--- a/packaging/plf-packaging-resources/src/main/resources/portlet.xml
+++ b/packaging/plf-packaging-resources/src/main/resources/portlet.xml
@@ -23,16 +23,6 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd">
 
-  <!-- This filter collects runtime request statistics -->
-  <filter>
-    <filter-name>org.exoplatform.portal.application.ApplicationMonitoringFilter</filter-name>
-    <filter-class>org.exoplatform.portal.application.ApplicationMonitoringFilter</filter-class>
-    <lifecycle>ACTION_PHASE</lifecycle>
-    <lifecycle>RENDER_PHASE</lifecycle>
-    <lifecycle>EVENT_PHASE</lifecycle>
-    <lifecycle>RESOURCE_PHASE</lifecycle>
-  </filter>
-
   <!-- This filter avoid displaying disabled portlets switch kernel profiles -->
   <filter>
     <filter-name>org.exoplatform.portal.application.PortletDisablerFilter</filter-name>


### PR DESCRIPTION
ApplicationMonitoringFilter has to be deleted since it's not used and will be redefined in new analytics addon when needed.