### PR TITLE
MAINT-28719: Prevent Mysql 8.0 authentification issue while using distant instance

### DIFF
--- a/packaging/plf-tomcat-resources/src/main/resources/conf/mysql.filters.properties
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/mysql.filters.properties
@@ -21,5 +21,5 @@ driverClassName=com.mysql.jdbc.Driver
 username=plf
 password=plf
 url=jdbc:mysql://localhost:3306/plf
-connectionParameters=?autoReconnect=true
+connectionParameters=?autoReconnect=true&amp;allowPublicKeyRetrieval=true
 jpaConnectionParameters=?autoReconnect=true&amp;characterEncoding=utf8


### PR DESCRIPTION
While connecting to MYSQL 8.0 from an external IP address. the server refuses the connection for security purposes. In order to fix this problem, we need to specify allowPublicKeyRetrieval=true argument