### PR TITLE
TASK-36239 Stabilize Cluster configuration for more stability

### DIFF
--- a/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
+++ b/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
@@ -705,29 +705,29 @@ gatein.jcr.index.cache.config=${exo.jcr.index.cache.config}
 # asyncInvalidation : Data invalidated asynchronously.
 
 # Calendar Cache Configuration
-exo.cache.Calendar.Calendar.cacheMode=asyncReplication
-exo.cache.calendar.CalendarEvent.cacheMode=asyncReplication
-exo.cache.calendar.EventCategories.cacheMode=asyncReplication
-exo.cache.calendar.GroupCalendar.cacheMode=asyncReplication
-exo.cache.calendar.GroupCalendarEvent.cacheMode=asyncReplication
-exo.cache.calendar.GroupCalendarRecurrentEvent.cacheMode=asyncReplication
+exo.cache.Calendar.Calendar.cacheMode=asyncInvalidation
+exo.cache.calendar.CalendarEvent.cacheMode=asyncInvalidation
+exo.cache.calendar.EventCategories.cacheMode=asyncInvalidation
+exo.cache.calendar.GroupCalendar.cacheMode=asyncInvalidation
+exo.cache.calendar.GroupCalendarEvent.cacheMode=asyncInvalidation
+exo.cache.calendar.GroupCalendarRecurrentEvent.cacheMode=asyncInvalidation
 exo.cache.calendar.UserCalendar.cacheMode=asyncInvalidation
 exo.cache.calendar.UserCalendarSetting.cacheMode=asyncInvalidation
 
 # forum Cache Configuration
-exo.cache.forum.BBCodeData.cacheMode=asyncReplication
-exo.cache.forum.BBCodeListData.cacheMode=asyncReplication
-exo.cache.forum.CategoryData.cacheMode=asyncReplication
+exo.cache.forum.BBCodeData.cacheMode=asyncInvalidation
+exo.cache.forum.BBCodeListData.cacheMode=asyncInvalidation
+exo.cache.forum.CategoryData.cacheMode=asyncInvalidation
 exo.cache.forum.CategoryList.cacheMode=asyncInvalidation
-exo.cache.forum.ForumData.cacheMode=asyncReplication
+exo.cache.forum.ForumData.cacheMode=asyncInvalidation
 exo.cache.forum.ForumList.cacheMode=asyncInvalidation
 exo.cache.forum.LinkListData.cacheMode=asyncInvalidation
 exo.cache.forum.LoginUserProfile.cacheMode=asyncInvalidation
-exo.cache.forum.MiscData.cacheMode=asyncReplication
-exo.cache.forum.ObjectNameData.cacheMode=asyncReplication
-exo.cache.forum.PostData.cacheMode=asyncReplication
+exo.cache.forum.MiscData.cacheMode=asyncInvalidation
+exo.cache.forum.ObjectNameData.cacheMode=asyncInvalidation
+exo.cache.forum.PostData.cacheMode=asyncInvalidation
 exo.cache.forum.PostList.cacheMode=asyncInvalidation
-exo.cache.forum.TopicData.cacheMode=asyncReplication
+exo.cache.forum.TopicData.cacheMode=asyncInvalidation
 exo.cache.forum.TopicList.cacheMode=asyncInvalidation
 exo.cache.forum.TopicListCount.cacheMode=asyncInvalidation
 exo.cache.forum.UserProfileList.cacheMode=asyncInvalidation
@@ -737,20 +737,22 @@ exo.cache.forum.PostListCount.cacheMode=asyncInvalidation
 exo.cache.forum.UserProfile.cacheMode=asyncInvalidation
 
 # wiki Cache Configuration
-exo.cache.wiki.PageAttachmentCache.cacheMode=asyncReplication
-exo.cache.wiki.PageRenderingCache.cacheMode=asyncReplication
+exo.cache.wiki.PageAttachmentCache.cacheMode=asyncInvalidation
+exo.cache.wiki.PageRenderingCache.cacheMode=asyncInvalidation
 
 # social Cache Configuration
 exo.cache.social.ActiveIdentitiesCache.cacheMode=asyncInvalidation
-exo.cache.social.ActivityCache.cacheMode=asyncReplication
+exo.cache.social.ActivityCache.cacheMode=asyncInvalidation
+exo.cache.social.ActivitiesCache.cacheMode=asyncInvalidation
+exo.cache.social.ActivitiesCountCache.cacheMode=asyncInvalidation
 exo.cache.social.IdentitiesCache.cacheMode=asyncInvalidation
 exo.cache.social.ProfileCache.cacheMode=asyncInvalidation
-exo.cache.social.RelationshipCache.cacheMode=asyncReplication
-exo.cache.social.RelationshipFromIdentityCache.cacheMode=asyncReplication
-exo.cache.social.RelationshipsCache.cacheMode=asyncReplication
-exo.cache.social.RelationshipsCountCache.cacheMode=asyncReplication
-exo.cache.social.SpaceCache.cacheMode=asyncReplication
-exo.cache.social.SpaceRefCache.cacheMode=asyncReplication
+exo.cache.social.RelationshipCache.cacheMode=asyncInvalidation
+exo.cache.social.RelationshipFromIdentityCache.cacheMode=asyncInvalidation
+exo.cache.social.RelationshipsCache.cacheMode=asyncInvalidation
+exo.cache.social.RelationshipsCountCache.cacheMode=asyncInvalidation
+exo.cache.social.SpaceCache.cacheMode=asyncInvalidation
+exo.cache.social.SpaceRefCache.cacheMode=asyncInvalidation
 exo.cache.social.SpacesCache.cacheMode=asyncInvalidation
 exo.cache.social.SuggestionsCache.cacheMode=asyncInvalidation
 exo.cache.social.IdentitiesCountCache.cacheMode=asyncInvalidation
@@ -759,10 +761,11 @@ exo.cache.social.IdentityIndexCache.cacheMode=asyncInvalidation
 exo.cache.social.SpacesCountCache.cacheMode=asyncInvalidation
 
 # portal Cache Configuration
-exo.cache.portal.description.cacheMode=asyncReplication
+exo.cache.portal.description.cacheMode=asyncInvalidation
 exo.cache.portal.mop.cacheMode=asyncInvalidation
 exo.cache.portal.navigation.cacheMode=asyncInvalidation
 exo.cache.portal.page.cacheMode=asyncInvalidation
+exo.cache.portal.portalconfig.cacheMode=asyncInvalidation
 exo.cache.portal.template.cacheMode=asyncInvalidation
 exo.cache.portal.templateservice.cacheMode=asyncInvalidation
 exo.cache.portal.user.cacheMode=asyncInvalidation
@@ -772,19 +775,19 @@ exo.cache.portal.role.cacheMode=asyncInvalidation
 exo.cache.portal.group.cacheMode=asyncInvalidation
 
 # ecms Cache Configuration
-exo.cache.ecms.templateservice.cacheMode=asyncReplication
-exo.cache.ecms.folkservice.cacheMode=asyncReplication
+exo.cache.ecms.templateservice.cacheMode=asyncInvalidation
+exo.cache.ecms.folkservice.cacheMode=asyncInvalidation
 exo.cache.ecms.lockservice.cacheMode=replication
-exo.cache.ecms.pdfviewer.cacheMode=syncInvalidation
-exo.cache.ecms.managedrive.cacheMode=syncInvalidation
-exo.cache.ecms.seoservice.cacheMode=asyncReplication
-exo.cache.ecms.javascript.cacheMode=asyncReplication
-exo.cache.ecms.queryservice.cacheMode=asyncReplication
+exo.cache.ecms.pdfviewer.cacheMode=asyncInvalidation
+exo.cache.ecms.managedrive.cacheMode=asyncInvalidation
+exo.cache.ecms.seoservice.cacheMode=asyncInvalidation
+exo.cache.ecms.javascript.cacheMode=asyncInvalidation
+exo.cache.ecms.queryservice.cacheMode=asyncInvalidation
 
 # commons Cache Configuration
-exo.cache.commons.WebNotificationCountCache.cacheMode=asyncReplication
-exo.cache.commons.WebNotificationsCache.cacheMode=asyncReplication
-exo.cache.commons.WebNotificationCache.cacheMode=asyncReplication
+exo.cache.commons.WebNotificationCountCache.cacheMode=asyncInvalidation
+exo.cache.commons.WebNotificationsCache.cacheMode=asyncInvalidation
+exo.cache.commons.WebNotificationCache.cacheMode=asyncInvalidation
 exo.cache.commons.SettingService=asyncInvalidation
 exo.cache.commons.UserSettingService.cacheMode=asyncInvalidation
 exo.cache.commons.UserStateService.cacheMode=asyncReplication


### PR DESCRIPTION
Change default configuration of clustered caches to ensure cluster stability by avoiding replicating objects through jGroups and prefer to invalidate other cluster nodes cached entries.
In fact, some cache entries are valid and usable only on one cluster node, especially for cache entries that references the logged in user.  Knowing that we use sticky session strategy for Load Balancing, replicating all cache entries doesn't worth it.

The changes that are made here was originally added in the following PR that wasn't added to product to cluster strategy low priority (before) : https://github.com/exodev/platform/pull/297