### PR TITLE
TASK-36859 Fix OORT static cluster nodes computing

### DIFF
--- a/packaging/plf-tomcat-resources/src/main/resources/bin/setenv.sh
+++ b/packaging/plf-tomcat-resources/src/main/resources/bin/setenv.sh
@@ -128,6 +128,18 @@ if [ "${EXO_CLUSTER}" = "true" ]; then
           EXO_CLUSTER_HOSTS_TCP_1="${EXO_CLUSTER_HOSTS_TCP_1},${exo_cluster_address}[${exo_cluster_tcp1_port}]"
         fi
 
+        if [ "${exo_cluster_name}"  !=  "${EXO_CLUSTER_NODE_NAME}" ]; then
+          if [ -z $EXO_CLUSTER_OORT_CLOUD ]; then
+            EXO_CLUSTER_OORT_CLOUD="${exo_cluster_http_protocol}://${exo_cluster_address}:${exo_cluster_http_port}/cometd/cometd"
+          else
+            EXO_CLUSTER_OORT_CLOUD="${EXO_CLUSTER_OORT_CLOUD},${exo_cluster_http_protocol}://${exo_cluster_address}:${exo_cluster_http_port}/cometd/cometd"
+          fi
+        fi
+
+        if [ -z $EXO_CLUSTER_OORT_CLOUD ]; then
+          EXO_CLUSTER_OORT_CLOUD=""
+        fi
+
         if [ -z $EXO_CLUSTER_HOSTS_TCP_2 ]; then
           EXO_CLUSTER_HOSTS_TCP_2="${exo_cluster_address}[${exo_cluster_tcp2_port}]"
         else
@@ -138,6 +150,7 @@ if [ "${EXO_CLUSTER}" = "true" ]; then
 
     CATALINA_OPTS="${CATALINA_OPTS} -Dexo.jcr.cluster.jgroups.tcpping.initial_hosts=${EXO_CLUSTER_HOSTS_TCP_1}"
     CATALINA_OPTS="${CATALINA_OPTS} -Dexo.service.cluster.jgroups.tcpping.initial_hosts=${EXO_CLUSTER_HOSTS_TCP_2}"
+    CATALINA_OPTS="${CATALINA_OPTS} -Dexo.cometd.oort.cloud=${EXO_CLUSTER_OORT_CLOUD}"
   fi
 else
   CATALINA_OPTS="${CATALINA_OPTS} -Dexo.cluster.node.name="

--- a/packaging/plf-tomcat-resources/src/main/resources/bin/setenv.sh
+++ b/packaging/plf-tomcat-resources/src/main/resources/bin/setenv.sh
@@ -136,10 +136,6 @@ if [ "${EXO_CLUSTER}" = "true" ]; then
           fi
         fi
 
-        if [ -z $EXO_CLUSTER_OORT_CLOUD ]; then
-          EXO_CLUSTER_OORT_CLOUD=""
-        fi
-
         if [ -z $EXO_CLUSTER_HOSTS_TCP_2 ]; then
           EXO_CLUSTER_HOSTS_TCP_2="${exo_cluster_address}[${exo_cluster_tcp2_port}]"
         else
@@ -147,6 +143,10 @@ if [ "${EXO_CLUSTER}" = "true" ]; then
         fi
       done
     done
+
+    if [ -z $EXO_CLUSTER_OORT_CLOUD ]; then
+      EXO_CLUSTER_OORT_CLOUD=""
+    fi
 
     CATALINA_OPTS="${CATALINA_OPTS} -Dexo.jcr.cluster.jgroups.tcpping.initial_hosts=${EXO_CLUSTER_HOSTS_TCP_1}"
     CATALINA_OPTS="${CATALINA_OPTS} -Dexo.service.cluster.jgroups.tcpping.initial_hosts=${EXO_CLUSTER_HOSTS_TCP_2}"

--- a/packaging/plf-tomcat-resources/src/main/resources/conf/logback.xml
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/logback.xml
@@ -90,6 +90,7 @@ For more details see : http://logback.qos.ch/manual/configuration.html
   <logger name="org.apache.tomcat.util.digester.Digester" level="ERROR" />
   <logger name="org.apache.catalina.realm.JAASRealm" level="ERROR"/>
   <logger name="org.cometd.websocket.server" level="WARN" />
+  <logger name="org.cometd.oort.Oort" level="ERROR" />
   <if condition='"true".equals(property("EXO_LOGS_DISPLAY_CONSOLE"))'>
     <then>
       <!-- This is activated by default on unix like systems -->


### PR DESCRIPTION
In fact, when using oort.configType = static, the value of exo.cometd.oort.cloud has to keep the URL of other nodes only (current node URL must not be added).
In addition, the logback.xml has been modified to ensure to not pollute logs when not all cluster nodes are up and running (Failed to connect warning are shown).