### PR TITLE
Task-40808 : [Security] Tomcat is leaking version information

### DIFF
--- a/packaging/plf-tomcat-resources/src/main/resources/conf/server.template.xml
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/server.template.xml
@@ -182,7 +182,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
         -->
-
+        
+        <!-- do not display server information like version on error pages -->
+        <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />
+        
         <!-- Be aware of the reverse proxy environment -->
         <Valve className="org.apache.catalina.valves.RemoteIpValve" remoteIpHeader="x-forwarded-for" proxiesHeader="x-forwarded-by" protocolHeader="x-forwarded-proto" />
       </Host>


### PR DESCRIPTION
Before this fix on certain error, tomcat is leaking version information :
curl -ki --path-as-is "https://community.exoplatform.org/portal/../..;/";

This fix configure errorValve to not disclose version information