### PR TITLE
Include time in assets default version

### DIFF
--- a/services/plf-configuration/pom.xml
+++ b/services/plf-configuration/pom.xml
@@ -26,6 +26,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <artifactId>plf-configuration</artifactId>
   <packaging>jar</packaging>
   <name>eXo Meeds:: Meeds Public Distribution - Services - Container Config</name>
+  <properties>
+     <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
+     <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
+  </properties>
   <build>
     <resources>
       <!-- Filtered resources -->

--- a/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
+++ b/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
@@ -832,7 +832,7 @@ gatein.portal.controller.config=${exo.conf.dir}/controller.xml
 gatein.portlet.config=${exo.conf.dir}/portlet.xml
 
 # Assets versions used in static resources URLs. Useful to manage caches. (Default: The product version - The product revision)
-gatein.assets.version=${exo.assets.version:@project.version@-@timestamp@}
+gatein.assets.version=${exo.assets.version:@project.version@-@buildTimestamp@}
 
 gatein.portal.resetpassword.expiretime=${exo.portal.resetpassword.expiretime:24}
 


### PR DESCRIPTION
Prior to this change, when restarting an acceptance server with newer developments the same day, the assets version is still the same and the browser caches aren't refreshed.
By including time in asset version, not only date, no more need to force refresh or to clear browser cache to see the updates made the same day.