### PR TITLE
TASK-26265 centralise third party libraries versions in maven-depmgt-pom

### DIFF
--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-addons-component.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-addons-component.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <dependencySets>
     <!-- eXo Platform Add-ons Manager - Unix Script -->
     <dependencySet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <includes>
         <include>org.exoplatform.platform:addons-manager:zip</include>
       </includes>
@@ -39,7 +39,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <!-- eXo Platform Add-ons Manager - Windows Script -->
     <dependencySet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <includes>
         <include>org.exoplatform.platform:addons-manager:zip</include>
       </includes>
@@ -57,7 +57,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <!-- eXo Platform Add-ons Manager - Others files -->
     <dependencySet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <includes>
         <include>org.exoplatform.platform:addons-manager:zip</include>
       </includes>

--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
@@ -23,7 +23,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- ================================ -->
     <!-- Libraries to put in Tomcat lib directory -->
     <dependencySet>
-      <outputDirectory>/lib</outputDirectory>
+      <outputDirectory>${file.separator}lib</outputDirectory>
       <includes>
         <include>*:*:jar</include>
       </includes>

--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-exo-tools-component.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-exo-tools-component.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <dependencySets>
 
     <dependencySet>
-      <outputDirectory>/bin</outputDirectory>
+      <outputDirectory>${file.separator}bin</outputDirectory>
       <includes>
         <include>io.meeds.distribution:plf-exo-tools:jar</include>
       </includes>

--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-default-tomcat-distribution-content.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-default-tomcat-distribution-content.xml
@@ -26,8 +26,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <fileSets>
     <!-- Unix shell scripts with exec rights -->
     <fileSet>
-      <outputDirectory>/</outputDirectory>
-      <directory>${project.build.directory}/${project.build.finalName}/dependencies/apache-tomcat/apache-tomcat-${org.apache.tomcat.version}/</directory>
+      <outputDirectory>${file.separator}</outputDirectory>
+      <directory>${project.build.directory}/${project.build.finalName}/dependencies/apache-tomcat/</directory>
       <fileMode>0755</fileMode>
       <filtered>false</filtered>
       <lineEnding>keep</lineEnding>
@@ -37,8 +37,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </fileSet>
     <!-- Others files -->
     <fileSet>
-      <outputDirectory>/</outputDirectory>
-      <directory>${project.build.directory}/${project.build.finalName}/dependencies/apache-tomcat/apache-tomcat-${org.apache.tomcat.version}/</directory>
+      <outputDirectory>${file.separator}</outputDirectory>
+      <directory>${project.build.directory}/${project.build.finalName}/dependencies/apache-tomcat/</directory>
       <filtered>false</filtered>
       <lineEnding>keep</lineEnding>
       <excludes>
@@ -58,7 +58,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </fileSet>
     <!-- Unix shell scripts with exec rights -->
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <directory>${project.build.directory}/${project.build.finalName}/dependencies/plf-tomcat-resources/</directory>
       <fileMode>0755</fileMode>
       <filtered>true</filtered>
@@ -69,7 +69,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </fileSet>
     <!-- Others files to filter -->
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <directory>${project.build.directory}/${project.build.finalName}/dependencies/plf-tomcat-resources/</directory>
       <filtered>true</filtered>
       <lineEnding>windows</lineEnding>
@@ -88,7 +88,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </fileSet>
     <!-- Don't filter others files -->
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <directory>${project.build.directory}/${project.build.finalName}/dependencies/plf-tomcat-resources/</directory>
       <filtered>false</filtered>
       <lineEnding>keep</lineEnding>
@@ -106,7 +106,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </fileSet>
     <!-- eXo platform - License file and related -->
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <directory>${project.build.directory}/maven-shared-archive-resources/</directory>
       <filtered>false</filtered>
       <lineEnding>windows</lineEnding>
@@ -119,7 +119,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- Local resources from the project - to allow to override -->
     <!-- Unix shell scripts with exec rights -->
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <directory>${project.basedir}/src/main/resources/</directory>
       <fileMode>0755</fileMode>
       <filtered>true</filtered>
@@ -130,7 +130,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </fileSet>
     <!-- Others files to filter -->
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <directory>${project.basedir}/src/main/resources/</directory>
       <filtered>true</filtered>
       <lineEnding>windows</lineEnding>
@@ -144,7 +144,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </fileSet>
     <!-- Don't filter others files -->
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <directory>${project.basedir}/src/main/resources/</directory>
       <filtered>false</filtered>
       <lineEnding>keep</lineEnding>
@@ -159,7 +159,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </fileSet>
     <!-- Configuration sample files -->
     <fileSet>
-      <outputDirectory>/gatein/conf</outputDirectory>
+      <outputDirectory>gatein/conf</outputDirectory>
       <directory>${project.build.directory}/${project.build.finalName}/dependencies/plf-configuration/conf/platform/</directory>
       <filtered>false</filtered>
       <lineEnding>windows</lineEnding>
@@ -171,7 +171,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <files>
     <!-- Default server.xml file -->
     <file>
-      <outputDirectory>/conf/</outputDirectory>
+      <outputDirectory>${file.separator}conf</outputDirectory>
       <destName>server.xml</destName>
       <source>${project.build.directory}/${project.build.finalName}/dependencies/plf-tomcat-resources/conf/server.template.xml</source>
       <filtered>true</filtered>
@@ -181,7 +181,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <dependencySets>
     <!-- Extract license file -->
     <dependencySet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <includes>
         <include>org.exoplatform.resources:exo-lgpl-license-resource-bundle:*</include>
       </includes>
@@ -196,7 +196,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <!-- Common Gatein Configuration -->
     <dependencySet>
-      <outputDirectory>/gatein/conf</outputDirectory>
+      <outputDirectory>${file.separator}gatein${file.separator}conf</outputDirectory>
       <includes>
         <include>io.meeds.distribution:plf-packaging-resources:zip</include>
       </includes>
@@ -214,7 +214,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <!-- CHANGE_LOG, README, RELEASE_NOTES -->
     <dependencySet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <includes>
         <include>io.meeds.distribution:plf-packaging-resources:zip</include>
       </includes>
@@ -235,7 +235,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependencySet>
     <!-- We only authorize this additional tomcat artifact for now -->
     <dependencySet>
-      <outputDirectory>/lib</outputDirectory>
+      <outputDirectory>${file.separator}lib</outputDirectory>
       <includes>
         <!-- This artifact isn't by default in tomcat -->
         <include>org.apache.tomcat:tomcat-catalina-jmx-remote:*</include>
@@ -248,7 +248,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- we reference each war to package -->
     <!-- ================================ -->
     <dependencySet>
-      <outputDirectory>/webapps</outputDirectory>
+      <outputDirectory>${file.separator}webapps</outputDirectory>
       <includes>
         <include>org.exoplatform.gatein.portal:*:war</include>
         <include>org.exoplatform.commons:*:war</include>

--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-default-tomcat-extract-dependencies.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-default-tomcat-extract-dependencies.xml
@@ -24,16 +24,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <includeBaseDirectory>true</includeBaseDirectory>
   <baseDirectory>dependencies</baseDirectory>
   <dependencySets>
-    <!-- Apache Tomcat Bundle -->
-    <dependencySet>
-      <outputDirectory>apache-tomcat</outputDirectory>
-      <includes>
-        <include>org.apache.tomcat:tomcat:zip</include>
-      </includes>
-      <scope>provided</scope>
-      <unpack>true</unpack>
-      <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
     <!-- Common Tomcat resources for PLF -->
     <dependencySet>
       <outputDirectory>plf-tomcat-resources</outputDirectory>

--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-server-xml-hsqldb.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-server-xml-hsqldb.xml
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <files>
     <!-- Default server.xml file -->
     <file>
-      <outputDirectory>/conf/</outputDirectory>
+      <outputDirectory>${file.separator}conf</outputDirectory>
       <destName>server-hsqldb.xml</destName>
       <source>${project.build.directory}/${project.build.finalName}/dependencies/plf-tomcat-resources/conf/server.template.xml</source>
       <filtered>true</filtered>

--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-server-xml-mysql.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-server-xml-mysql.xml
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <files>
     <!-- Default server.xml file -->
     <file>
-      <outputDirectory>/conf/</outputDirectory>
+      <outputDirectory>${file.separator}conf</outputDirectory>
       <destName>server-mysql.xml</destName>
       <source>${project.build.directory}/${project.build.finalName}/dependencies/plf-tomcat-resources/conf/server.template.xml</source>
       <filtered>true</filtered>

--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-server-xml-postgres.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-server-xml-postgres.xml
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <files>
     <!-- Default server.xml file -->
     <file>
-      <outputDirectory>/conf/</outputDirectory>
+      <outputDirectory>${file.separator}conf</outputDirectory>
       <destName>server-postgres.xml</destName>
       <source>${project.build.directory}/${project.build.finalName}/dependencies/plf-tomcat-resources/conf/server.template.xml</source>
       <filtered>true</filtered>

--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-server-xml-postgresplus.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-server-xml-postgresplus.xml
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <files>
     <!-- Default server.xml file -->
     <file>
-      <outputDirectory>/conf/</outputDirectory>
+      <outputDirectory>${file.separator}conf</outputDirectory>
       <destName>server-postgresplus.xml</destName>
       <source>${project.build.directory}/${project.build.finalName}/dependencies/plf-tomcat-resources/conf/server.template.xml</source>
       <filtered>true</filtered>

--- a/packaging/plf-assemblies/src/main/resources/assemblies/project-resources-zip.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/project-resources-zip.xml
@@ -24,7 +24,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>${file.separator}</outputDirectory>
       <directory>${project.basedir}/src/main/resources/</directory>
       <filtered>false</filtered>
       <lineEnding>keep</lineEnding>

--- a/packaging/plf-community-tomcat-standalone/pom.xml
+++ b/packaging/plf-community-tomcat-standalone/pom.xml
@@ -110,6 +110,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <!-- The name that we'll use for our distribution directory -->
@@ -150,6 +156,29 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <configuration>
               <timestampFormat>dd/MM/yyyy</timestampFormat>
               <timestampPropertyName>build.date</timestampPropertyName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>apache-tomcat</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.apache.tomcat</groupId>
+                  <artifactId>tomcat</artifactId>
+                  <type>zip</type>
+                  <outputDirectory>${project.build.directory}/${project.build.finalName}/dependencies/apache-tomcat</outputDirectory>
+                  <includes>apache-tomcat*/**</includes>
+                </artifactItem>
+              </artifactItems>
             </configuration>
           </execution>
         </executions>
@@ -261,6 +290,25 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
+          <execution>
+            <id>remove-tomcat-version-from-folder</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- Remove tomcat version from folder name to avoid declaring tomcat version in current module
+                  for more flexibility when upgrading Tomcat -->
+                <move todir="${project.build.directory}/${project.build.finalName}/dependencies/apache-tomcat">
+                  <fileset dir="${project.build.directory}/${project.build.finalName}/dependencies/apache-tomcat/">
+                    <include name="**/apache-tomcat-*/**" />
+                  </fileset>
+                  <mapper type="regexp" from="^(.*)apache-tomcat-([^/]+)(.*)" to="\1/\3" />
+                </move>
+              </target>
+            </configuration>
+          </execution>
           <execution>
             <id>install-add-ons</id>
             <phase>prepare-package</phase>

--- a/packaging/plf-dependencies/pom.xml
+++ b/packaging/plf-dependencies/pom.xml
@@ -89,6 +89,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <groupId>org.exoplatform.social</groupId>
       <artifactId>social-extension-war</artifactId>
       <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.social</groupId>
@@ -158,6 +164,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.management</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
@@ -191,8 +203,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependency>
     <!-- org.gatein.security.oauth.webapi.OAuthDelegateFilter used but not declared in GateIn ? -->
     <dependency>
-      <groupId>org.gatein.cdi</groupId>
-      <artifactId>gatein-cdi-injection</artifactId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.cdi.injection</artifactId>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
@@ -228,13 +240,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <artifactId>portals-bridges-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.gatein.cdi</groupId>
-      <artifactId>gatein-cdi-contexts</artifactId>
-      <type>jar</type>
-    </dependency>
-    <dependency>
-      <groupId>javax.ccpp</groupId>
-      <artifactId>ccpp</artifactId>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.cdi.contexts</artifactId>
       <type>jar</type>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,18 +42,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </scm>
   <properties>
     <!-- **************************************** -->
-    <!-- Jira Settings                            -->
-    <!-- **************************************** -->
-    <jira.project.key>PLF</jira.project.key>
-    <!-- **************************************** -->
-    <!-- Repository settings                      -->
-    <!-- **************************************** -->
-    <exo.snapshots.repo.url>https://repository.exoplatform.org/content/repositories/meeds-snapshots</exo.snapshots.repo.url>
-    <!-- **************************************** -->
-    <!-- Jenkins Settings                         -->
-    <!-- **************************************** -->
-    <jenkins.job.name>meeds-master-pkg</jenkins.job.name>
-    <!-- **************************************** -->
     <!-- Dependencies Versions                    -->
     <!-- **************************************** -->
     <!-- The version of Platform To bundle -->
@@ -61,22 +49,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <org.exoplatform.platform-ui.version>6.2.x-SNAPSHOT</org.exoplatform.platform-ui.version>
     <!-- The version of the add-ons manager -->
     <org.exoplatform.platform.addons-manager.version>2.2.x-SNAPSHOT</org.exoplatform.platform.addons-manager.version>
-    <!-- The apache tomcat version to bundle -->
-    <org.apache.tomcat.version>8.5.55</org.apache.tomcat.version>
-    <!-- SLF4J version to use to wrap all loggers in our product and its dependencies -->
-    <org.slf4j.version>1.7.7</org.slf4j.version>
-    <!-- LOGBACK implementation to use to manage logs -->
-    <ch.qas.logback.version>1.1.2</ch.qas.logback.version>
-    <!-- Additional LOGBACK dependencies -->
-    <org.codehaus.janino.version>2.6.1</org.codehaus.janino.version>
-    <org.fusesource.jansi.version>1.11</org.fusesource.jansi.version>
-    <!-- PLF-6409: Liquibase dependency -->
-    <org.snakeyaml.version>1.13</org.snakeyaml.version>
-    <!-- ************** -->
-    <!-- Build settings -->
-    <!-- ************** -->
-    <!-- maven-release-plugin -->
-    <preparationGoals>clean install</preparationGoals>
     <!-- ************** -->
     <!-- Add-ons for Community packaging   -->
     <!-- ************** -->
@@ -99,12 +71,26 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </properties>
   <dependencyManagement>
     <dependencies>
+      <!-- Dependencies -->
       <dependency>
         <groupId>org.exoplatform.social</groupId>
         <artifactId>social</artifactId>
         <version>${org.exoplatform.social.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.exoplatform.platform-ui</groupId>
+        <artifactId>platform-ui</artifactId>
+        <version>${org.exoplatform.platform-ui.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.exoplatform.platform</groupId>
+        <artifactId>addons-manager</artifactId>
+        <version>${org.exoplatform.platform.addons-manager.version}</version>
+        <type>zip</type>
       </dependency>
       <!-- Pre-bundled addons -->
       <dependency>
@@ -155,57 +141,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <version>${addon.exo.app-center.version}</version>
         <type>zip</type>
         <scope>provided</scope>
-      </dependency>
-      <!-- Dependencies -->
-      <dependency>
-        <groupId>org.exoplatform.platform-ui</groupId>
-        <artifactId>platform-ui</artifactId>
-        <version>${org.exoplatform.platform-ui.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Logging implementation : http://logback.qos.ch/ -->
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${ch.qas.logback.version}</version>
-      </dependency>
-      <!-- Official Apache Distribution -->
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat</artifactId>
-        <version>${org.apache.tomcat.version}</version>
-        <type>zip</type>
-      </dependency>
-      <!-- Used to write a listener -->
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-catalina</artifactId>
-        <version>${org.apache.tomcat.version}</version>
-      </dependency>
-      <!-- Additional Tomcat JAR to allow to fix JMX ports. Useful when the server is behind a firewall -->
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-catalina-jmx-remote</artifactId>
-        <version>${org.apache.tomcat.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-util</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <!-- Required by conditional processing in logback -->
-      <dependency>
-        <groupId>org.codehaus.janino</groupId>
-        <artifactId>janino</artifactId>
-        <version>${org.codehaus.janino.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.platform</groupId>
-        <artifactId>addons-manager</artifactId>
-        <version>${org.exoplatform.platform.addons-manager.version}</version>
-        <type>zip</type>
       </dependency>
       <!-- Project artifacts -->
       <dependency>
@@ -330,44 +265,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <artifactId>plf-tomcat-resources</artifactId>
         <version>${project.version}</version>
         <type>zip</type>
-      </dependency>
-      <!-- Required by logback for colorized console on windows -->
-      <dependency>
-        <groupId>org.fusesource.jansi</groupId>
-        <artifactId>jansi</artifactId>
-        <version>${org.fusesource.jansi.version}</version>
-      </dependency>
-      <!-- Use SLF4J and not commons-logging -->
-      <!-- commons-logging must be removed from dependencies -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>${org.slf4j.version}</version>
-      </dependency>
-      <!-- Redirect everything from JUL to SLF4J -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jul-to-slf4j</artifactId>
-        <version>${org.slf4j.version}</version>
-      </dependency>
-      <!-- Use SLF4J and not log4j -->
-      <!-- log4j must be removed from dependencies -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>log4j-over-slf4j</artifactId>
-        <version>${org.slf4j.version}</version>
-      </dependency>
-      <!-- SLF4J API -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${org.slf4j.version}</version>
-      </dependency>
-      <!-- PLF-6409: Required by Liquibase to not generate error -->
-      <dependency>
-        <groupId>org.yaml</groupId>
-        <artifactId>snakeyaml</artifactId>
-        <version>${org.snakeyaml.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -515,32 +412,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>project-repositories</id>
-      <activation>
-        <property>
-          <name>!skip-project-repositories</name>
-        </property>
-      </activation>
-      <repositories>
-        <repository>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-          <id>repository.exoplatform.org</id>
-          <url>https://repository.exoplatform.org/public</url>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-          <id>repository.exoplatform.org</id>
-          <url>https://repository.exoplatform.org/public</url>
-        </pluginRepository>
-      </pluginRepositories>
     </profile>
   </profiles>
 </project>

--- a/services/plf-tomcat-pc-creator-listener/pom.xml
+++ b/services/plf-tomcat-pc-creator-listener/pom.xml
@@ -58,7 +58,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.wci</groupId>
-      <artifactId>wci-tomcat8</artifactId>
+      <artifactId>wci-tomcat</artifactId>
     </dependency>
   </dependencies>
   <profiles>

--- a/services/plf-tomcat-pc-creator-listener/src/main/java/org/exoplatform/platform/server/tomcat/DataSourceInjector.java
+++ b/services/plf-tomcat-pc-creator-listener/src/main/java/org/exoplatform/platform/server/tomcat/DataSourceInjector.java
@@ -26,7 +26,7 @@ import javax.naming.NamingException;
 
 import org.apache.catalina.Engine;
 import org.apache.naming.factory.ResourceLinkFactory;
-import org.gatein.wci.tomcat.TC7ServletContainerContext;
+import org.gatein.wci.tomcat.TomcatServletContainerContext;
 
 import org.exoplatform.container.BaseContainerLifecyclePlugin;
 import org.exoplatform.container.ExoContainer;
@@ -67,12 +67,12 @@ public class DataSourceInjector extends BaseContainerLifecyclePlugin {
   }
 
   private Context getGlobalNamingContext() {
-    // TC7ContainerServlet will start when integration.war context is deployed.
-    // The TC7ContainerServlet instantiates the TC7ServletContainerContext.
+    // TomcatContainerServlet will start when integration.war context is deployed.
+    // The TomcatContainerServlet instantiates the TomcatServletContainerContext.
     // The integration.war is started before the PortalContainer starts
-    // So we are sure that the instance TC7ServletContainerContext is instantiated
+    // So we are sure that the instance TomcatServletContainerContext is instantiated
     // If not, an exception will be thrown in initContainer method and the server startup fails
-    TC7ServletContainerContext servletContainerContext = TC7ServletContainerContext.getInstanceIfPresent();
+    TomcatServletContainerContext servletContainerContext = TomcatServletContainerContext.getInstanceIfPresent();
     if (servletContainerContext != null) {
       Engine e = (Engine) servletContainerContext.getEngine();
       return e.getService().getServer().getGlobalNamingContext();

--- a/webapps/plf-tomcat-integration-webapp/pom.xml
+++ b/webapps/plf-tomcat-integration-webapp/pom.xml
@@ -29,12 +29,16 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <dependencies>
     <dependency>
       <groupId>org.exoplatform.gatein.wci</groupId>
-      <artifactId>wci-tomcat8</artifactId>
+      <artifactId>wci-tomcat</artifactId>
       <!-- Don't include apache tomcat artifacts to avoid conflicts in a tomcat appserver -->
       <exclusions>
         <exclusion>
           <artifactId>catalina</artifactId>
           <groupId>org.apache.tomcat</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/webapps/plf-tomcat-integration-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapps/plf-tomcat-integration-webapp/src/main/webapp/WEB-INF/web.xml
@@ -24,7 +24,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
   <servlet>
     <servlet-name>ContainerServlet</servlet-name>
-    <servlet-class>org.gatein.wci.tomcat.TC7ContainerServlet</servlet-class>
+    <servlet-class>org.gatein.wci.tomcat.TomcatContainerServlet</servlet-class>
     <load-on-startup>1</load-on-startup>
   </servlet>
 


### PR DESCRIPTION
This PR will :
* centralise jar dependencies in order to ensure jar versions coherence between all projects and avoid bad jar versions in runtime. This will ease the maintenance and update of jar dependencies as well.
* Rename tomcat8 dependant artifactIds and classes to be able to easily upgrade Tomcat version