### PR TITLE
Task-39995: Can't login to the platform while onlyoffice is uninstalled

### DIFF
--- a/packaging/plf-tomcat-resources/pom.xml
+++ b/packaging/plf-tomcat-resources/pom.xml
@@ -126,6 +126,20 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
     </dependency>
+    <!-- TASK-39995: Required to not generate error when login after uninstall onlyOffice addon-->
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Can't login to the platform while onlyoffice is uninstalled
Fix: Add jsonwebtoken dependency to packaging EE.