### PR TITLE
MAINT-52380:Increase default password policy min and max length validators

### DIFF
--- a/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
+++ b/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
@@ -921,9 +921,9 @@ exo.quartz.dataSource.quartzDS.jndiURL=${exo.quartz.dataSource.quartzDS.jndiURL:
 # Custom Password Policy
 #
 
-gatein.validators.passwordpolicy.regexp=${gatein.validators.passwordpolicy.regexp:((?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).\\{8,20\\})}
-gatein.validators.passwordpolicy.length.max=${gatein.validators.passwordpolicy.length.max:20}
-gatein.validators.passwordpolicy.length.min=${gatein.validators.passwordpolicy.length.min:8}
+gatein.validators.passwordpolicy.regexp=${gatein.validators.passwordpolicy.regexp:((?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).\\{9,256\\})}
+gatein.validators.passwordpolicy.length.max=${gatein.validators.passwordpolicy.length.max:256}
+gatein.validators.passwordpolicy.length.min=${gatein.validators.passwordpolicy.length.min:9}
 
 ###########################
 #


### PR DESCRIPTION
ISSUE: the default password length was 6 character min, and 20 characters max. Theses limitations makes the password weak regarding actual recommendations.
FIX: Increase the min and max length default validators to have at least 9 characters ((which is defined as the "low to medium" strength by the ANSII password recommendations). The recommendation also advise for not having maximum limit for the password. But to prevent potential attacks on that, we decide to put a huge limit to 256 characters. This upper limit will not be exposed to the user for security reason.