### PR TITLE
TASK-53984 Fix Branding Page application reference

### DIFF
--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/portal/group/platform/administrators/pages.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/portal/group/platform/administrators/pages.xml
@@ -82,7 +82,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <edit-permission>manager:/platform/administrators</edit-permission>
     <portlet-application>
       <portlet>
-        <application-ref>exoadmin</application-ref>
+        <application-ref>social-portlet</application-ref>
         <portlet-ref>Branding</portlet-ref>
       </portlet>
       <title>Branding Portlet</title>


### PR DESCRIPTION
Prior to this modification, the Branding Page is broken on Meeds package due to bad reference of Branding application which has been moved from GateIN to Social project.