### PR TITLE
Disable Hibernate WARN logs in production

### DIFF
--- a/packaging/plf-tomcat-resources/src/main/resources/conf/logback.xml
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/logback.xml
@@ -83,7 +83,7 @@ For more details see : http://logback.qos.ch/manual/configuration.html
   <logger name="ws" level="INFO" />
   <logger name="XMLResolvingServiceImpl" level="INFO" />
   <logger name="TRAXTemplatesServiceImpl" level="INFO" />
-  <logger name="org.hibernate" level="INFO" />
+  <logger name="org.hibernate" level="ERROR" />
   <logger name="com.arjuna" level="INFO" />
   <logger name="org.jboss" level="INFO" />
   <logger name="com.google.javascript.jscomp" level="WARN" />


### PR DESCRIPTION
Prior to this change, some useless logs are logged with Hibernate like:
```
WARN  | SQL Warning Code: -1100, SQLState: 02000 [o.h.engine.jdbc.spi.SqlExceptionHelper<main>] 
WARN  | no data [o.h.engine.jdbc.spi.SqlExceptionHelper<main>]
```
In addition, the recommended logging level for Hibernate in production mode is `ERROR`.