### PR TITLE
TASK-55597 Add JDK 17 support for runtime on Windows

### DIFF
--- a/packaging/plf-tomcat-resources/src/main/resources/bin/setenv.bat
+++ b/packaging/plf-tomcat-resources/src/main/resources/bin/setenv.bat
@@ -206,6 +206,7 @@ SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.base/java.nio=ALL-UNNAM
 SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.base/java.text=ALL-UNNAMED
 SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.base/java.util=ALL-UNNAMED
 SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
 SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.base/sun.nio.ch=ALL-UNNAMED
 SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.management/java.lang.management=ALL-UNNAMED
 SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.desktop/java.awt.font=ALL-UNNAMED


### PR DESCRIPTION
Prior to this change, when starting the Meeds package with JRE 17 on Windows, an error is raised about accessing `java.util.concurrent.atomic` package using reflection API. This change will fix this error.