### PR TITLE
Update poi library from 4.1.2 to 5.2.2 - EXO-59736 - Meeds-io/meeds#292

### DIFF
--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
@@ -37,7 +37,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <exclude>commons-logging:*</exclude>
         <!-- log4j is forbidden and must be replaced by org.slf4j:log4j-over-slf4j -->
         <exclude>log4j:*</exclude>
-        <exclude>org.apache.logging.log4j:*</exclude>
         <!-- We use jcl-over-slf4j, thus this one is forbidden to avoid infinite loops -->
         <exclude>org.slf4j:slf4j-jcl:*</exclude>
         <!-- We use log4j-over-slf4j, thus this one is forbidden to avoid infinite loops -->
@@ -90,8 +89,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <exclude>*:xmlParserAPIs:*</exclude>
         <!-- PLF-6122: Exclude icepdf older than 5.1.0. The groupId for Open Source bundles is now org.icepdf.os -->
         <exclude>org.icepdf:icepdf-core:*</exclude>
-        <!-- COR-338: Exclude Apache poi-ooxml 3.8. Platform uses now 3.8-eXo01 -->
-        <exclude>org.apache.poi:poi-ooxml:[3.8]</exclude>
         <!-- Avoid any direct addon inclusion on the distribution packages -->
         <exclude>org.exoplatform.addons.*:*</exclude>
       </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -407,8 +407,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                         <exclude>*:xmlParserAPIs:*</exclude>
                         <!-- PLF-6122: Exclude icepdf older than 5.1.0. The groupId for Open Source bundles is now org.icepdf.os -->
                         <exclude>org.icepdf:icepdf-core:*</exclude>
-                        <!-- COR-338: Exclude Apache poi-ooxml 3.8. Platform uses now 3.8-eXo01 -->
-                        <exclude>org.apache.poi:poi-ooxml:[3.8]</exclude>
                         <!-- DEP-101: Elasticsearch depends on lucene version incompatible with the JCR -->
                         <exclude>org.apache.lucene:*:4</exclude>
                       </excludes>
@@ -417,6 +415,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                         <include>org.apache.tomcat:tomcat-catalina-jmx-remote</include>
                         <!-- We can use the tomcat distro -->
                         <include>org.apache.tomcat:tomcat:zip</include>
+                        <!--only 1.0 of badArtifact is allowed-->
+                        <include>org.apache.logging.log4j:log4j-api:[2.18.0,)</include>
                       </includes>
                     </bannedDependencies>
                   </rules>


### PR DESCRIPTION
Before this change, a high vulnerability is observed in poi-scratchpad:4.1.2 library This fix update poi-scratchpad to the last available version 5.2.2 To follow this library update, this fix also update commons-io from 2.7 to 2.11.0 and xmlbeans from 3.1.0 to 5.0.3 In this fix, we allow the library log4j-api which is needed by poi library. We allow only version > 2.18.0. Other log4j libraries are still banned.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
