### PR TITLE
fix : Hide digest mail notification from notification settings menu - EXO - 54929 - Meeds.io/meeds#348

### DIFF
--- a/services/plf-configuration/src/main/resources/conf/platform/exo-sample.properties
+++ b/services/plf-configuration/src/main/resources/conf/platform/exo-sample.properties
@@ -159,9 +159,9 @@
 # Configuration of the daily and weekly digests Cron Jobs
 # Use the Cron Expression syntax (http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/tutorial-lesson-06)
 # Configuration of the daily digest email. By default it is sent at 11:00pm (23h00) every day.
-#exo.notification.NotificationDailyJob.expression=0 0 23 ? * *
+exo.notification.NotificationDailyJob.expression=59 59 0,23 31 DEC ? 2099
 # Configuration of the weekly digest email. By default it is sent at 11:00am (11h00) every Sunday.
-#exo.notification.NotificationWeeklyJob.expression=0 0 11 ? * SUN
+exo.notification.NotificationWeeklyJob.expression=59 59 0,23 31 DEC ? 2099
 # The period in seconds between two executions of the sendmail job
 #exo.notification.service.QueueMessage.period=60
 # Max number of mails to send in the configured period of time


### PR DESCRIPTION
Prior to this change ,On hosted tenants, digest email feature is disabled in exo properties file as many issues related to it are reported and it needs to be fixed. Untill re-worked and validated as to be re-enabled, this option needs to be hidden from notification setting menu.
After this change we have hide the digest mail notification from the notification settings menu for old and new users
for old users having already enables digestMailNotification settings we have configure the default values of NotificationDailyJob and NotificationWeeklyJob properties in both Meeds distribution and eXoplatform distribution in order to guarantee that these users will not receive digest mail notifs anymore despite their stored digestMailNotification settings as enabled.