### PR TITLE
feat: Overview Page change access permission - MEED-1015 - Meeds-io/MIPs#10

### DIFF
--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal/meeds/pages.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal/meeds/pages.xml
@@ -21,7 +21,7 @@ xmlns="http://www.exoplatform.org/xml/ns/gatein_objects_1_8">
   <page>
     <name>overview</name>
     <title>overview</title>
-    <access-permissions>*:/platform/rewarding</access-permissions>
+    <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
     <edit-permission>*:/platform/rewarding</edit-permission>
     <container id="meedsOverviewPage" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="VuetifyApp">
       <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>


### PR DESCRIPTION
Prior to this change, the overview page was only accessed for whom access privileges are `*:/platform/rewarding`, 
this change is going to change access permission to `*:/platform/users;*:/platform/externals `