### PR TITLE
fix: External users access to pages - MEED-1465

### DIFF
--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal/meeds/navigation.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal/meeds/navigation.xml
@@ -31,5 +31,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <label>#{portal.meeds.stream}</label>
       <page-reference>portal::global::stream</page-reference>
     </node>
+    <node>
+      <name>external-stream</name>
+      <label>#{portal.meeds.stream}</label>
+      <page-reference>portal::global::externalStream</page-reference>
+    </node>
   </page-nodes>
 </node-navigation>


### PR DESCRIPTION
Prior to this change, external users haven't a stream page on the meed site.
