### PR TITLE
feat: Add Perks and contributions pages in Meeds Site Top Navigation - MEED-1488 - Meeds-io/MIPs#36

### DIFF
--- a/webapps/plf-meeds-extension/src/main/resources/locale/navigation/portal/meeds_en.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/navigation/portal/meeds_en.properties
@@ -16,3 +16,5 @@
 #
 portal.meeds.stream=Stream
 portal.meeds.overview=Overview
+portal.meeds.contributions=Contributions
+portal.meeds.perks=Perks

--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal/meeds/navigation.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal/meeds/navigation.xml
@@ -25,6 +25,16 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <name>overview</name>
       <label>#{portal.meeds.overview}</label>
       <page-reference>portal::global::overview</page-reference>
+      <node>
+        <name>contributions</name>
+        <label>#{portal.meeds.contributions}</label>
+        <page-reference>portal::global::contributions</page-reference>
+      </node>
+      <node>
+        <name>perkstore</name>
+        <label>#{portal.meeds.perks}</label>
+        <page-reference>portal::global::perkstore</page-reference>
+      </node>
     </node>
     <node>
       <name>stream</name>


### PR DESCRIPTION
This change will introduce two new nodes as children of Overview page in order to display three items on Meeds Site: Overview, Perks and Contributions.