### PR TITLE
fix: Fix Crowdin synchronization Job That missed first files synchronizations - Meeds-io/MIPs#29

### DIFF
--- a/translations.properties
+++ b/translations.properties
@@ -16,7 +16,7 @@
 #
 
 # Mandatory property that indicate the base directory where each file is located in Crowdin (must end with /).
-baseDir=Platform/meeds/
+baseDir=platform/meeds/
 
 # Files
 meeds.properties=webapps/plf-meeds-extension/src/main/resources/locale/navigation/portal/meeds_en.properties

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ar.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ar.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_aro.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_aro.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_az.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_az.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ca.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ca.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ceb.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ceb.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_co.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_co.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_cs.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_cs.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_de.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_de.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_el.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_el.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_es_ES.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_es_ES.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_eu.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_eu.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_fa.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_fa.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_fi.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_fi.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_fil.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_fil.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_fr.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_fr.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_hi.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_hi.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_hu.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_hu.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_in.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_in.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_it.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_it.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ja.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ja.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ko.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ko.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_lt.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_lt.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ms.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ms.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_nl.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_nl.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_no.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_no.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_pcm.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_pcm.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_pl.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_pl.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_pt_BR.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_pt_BR.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_pt_PT.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_pt_PT.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ro.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ro.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ru.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ru.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_sk.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_sk.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_sl.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_sl.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_sq.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_sq.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_sv_SE.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_sv_SE.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_th.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_th.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_tl.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_tl.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_tr.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_tr.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_uk.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_uk.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ur_IN.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_ur_IN.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_vi.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_vi.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_zh_CN.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_zh_CN.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 

--- a/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_zh_TW.properties
+++ b/webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_zh_TW.properties
@@ -1,0 +1,2 @@
+UILoginForm.label.pageTitle=Work Metaverse
+UILoginForm.label.pageSubTitle=The future of work and engagement 


### PR DESCRIPTION
Prior to this change, the Login.properties crowdin synchronization had failed which leads to have the default placeholder labels of Left Side in Login Page for other languages than EN. This change will force to have EN default labels for other languages and will rename the parent folder fo files synchronization in lowercase to use the same name as other Meeds projects.