### PR TITLE
feat: Enable Restore Space Home Layout Feature by default for Meeds Package - MEED-1498 - Meeds-io/meeds#538

### DIFF
--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -24,5 +24,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <import>war:/conf/meeds/portal-configuration.xml</import>
   <import>war:/conf/meeds/resources-bundle-configuration.xml</import>
   <import>war:/conf/meeds/space-template-configuration.xml</import>
+  <import>war:/conf/meeds/features-configuration.xml</import>
 
 </configuration>

--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/features-configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/features-configuration.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<configuration
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+  <component>
+    <key>MeedsFeatureProperties</key>
+    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+    <init-params>
+      <properties-param>
+        <name>MeedsFeatureProperties</name>
+        <property name="exo.feature.SpaceHomeLayoutReset.enabled" value="${exo.feature.SpaceHomeLayoutReset.enabled:true}" />
+      </properties-param>
+    </init-params>
+  </component>
+</configuration>


### PR DESCRIPTION
The feature flag `exo.feature.SpaceHomeLayoutReset.enabled` is set by default in Social to allow DAO Members to enable it when needed only. This change will enable this feature by default for Meeds Package only.