### PR TITLE
feat: Define default value for profile page importMode in Meeds Package context - MEED-1556 - Meeds-io/meeds#564

### DIFF
--- a/webapps/plf-meeds-extension/src/main/webapp/META-INF/exo-conf/configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/META-INF/exo-conf/configuration.xml
@@ -26,6 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <properties-param>
         <name>MeedsPortalConfigProperties</name>
         <property name="exo.social.groups.portalConfig.metadata.importmode" value="${exo.social.groups.portalConfig.metadata.importmode:OVERWRITE}" />
+        <property name="exo.social.portalConfig.profilePage.importmode" value="${exo.social.portalConfig.profilePage.importmode:MERGE}" />
       </properties-param>
     </init-params>
   </component>


### PR DESCRIPTION
In order to make sure that profile page adaptations is taken into account in current installations, this change will change the default value to 'MERGE' in order to re-import the page layout from sources each startup.