### PR TITLE
fix: add property for profile ignored attributes to synchronize - EXO-62724 - meeds-io/meeds#762

### DIFF
--- a/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
+++ b/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
@@ -981,4 +981,5 @@ gatein.oauth.linkedin.apiKey=${exo.oauth.linkedin.apiKey}
 gatein.oauth.linkedin.apiSecret=${exo.oauth.linkedin.apiSecret}
 gatein.oauth.linkedin.redirectURL=${gatein.oauth.portal.url}/@@portal.container.name@@/linkedinAuth
 
-
+# Properties to ignore while synchronizing user portal profile with social user profile
+exo.social.profile.excluded.attributeList=user.social-info.openid.userName,user.social-info.openid.accessToken,user.social-info.openid.accessToken.2


### PR DESCRIPTION
Added a new property for profile attributes that will be ignore when synchronizing user portal profile with user social profile.