### PR TITLE
feat: Delete deprecated Web ARchives and disable WebUI in frontend - Meeds-io/MIPs#52 - MEED-1891

### DIFF
--- a/packaging/plf-dependencies/pom.xml
+++ b/packaging/plf-dependencies/pom.xml
@@ -30,24 +30,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- Portal  -->
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.portlet.exoadmin</artifactId>
-      <type>war</type>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.portlet.web</artifactId>
-      <type>war</type>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.web.eXoResources</artifactId>
-      <type>war</type>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.web.portal</artifactId>
       <type>war</type>
       <scope>runtime</scope>

--- a/packaging/plf-packaging-resources/src/main/resources/controller.xml
+++ b/packaging/plf-packaging-resources/src/main/resources/controller.xml
@@ -239,6 +239,21 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
   </route>
 
+  <!-- The space access check -->
+  <route path="/g/{gtn:sitename}/{gtn:path}">
+    <route-param qname="gtn:handler">
+      <value>space-access</value>
+    </route-param>
+    <request-param qname="gtn:lang" name="lang" value-mapping="never-empty">
+      <pattern>(ar|ar-AE|ar-BH|ar-DZ|ar-EG|ar-IQ|ar-JO|ar-KW|ar-LB|ar-LY|ar-MA|ar-OM|ar-QA|ar-SA|ar-SD|ar-SY|ar-TN|ar-YE|be|be-BY|bg|bg-BG|ca|ca-ES|cs|cs-CZ|da|da-DK|de|de-AT|de-CH|de-DE|de-GR|de-LU|el|el-CY|el-GR|en|en-AU|en-CA|en-GB|en-IE|en-IN|en-MT|en-NZ|en-PH|en-SG|en-US|en-ZA|es|es-AR|es-BO|es-CL|es-CO|es-CR|es-CU|es-DO|es-EC|es-ES|es-GT|es-HN|es-MX|es-NI|es-PA|es-PE|es-PR|es-PY|es-SV|es-US|es-UY|es-VE|et|et-EE|fa|fi|fi-FI|fil|fr|fr-BE|fr-CA|fr-CH|fr-FR|fr-LU|ga|ga-IE|hi|hi-IN|hr|hr-HR|hu|hu-HU|in|in-ID|is|is-IS|it|it-CH|it-IT|iw|iw-IL|ja|ja-JP|ja-JP-JP-#u-ca-japanese|ko|ko-KR|lt|lt-LT|lv|lv-LV|mk|mk-MK|ms|ms-MY|mt|mt-MT|nl|nl-BE|nl-NL|no|no-NO|no-NO-NY|pl|pl-PL|pt|pt-BR|pt-PT|ro|ro-RO|ru|ru-RU|sk|sk-SK|sl|sl-SI|sq|sq-AL|sr|sr-BA|sr-BA-#Latn|sr-CS|sr-ME|sr-ME-#Latn|sr-RS|sr-RS-#Latn|sr--#Latn|sv|sv-SE|th|th-TH|th-TH-TH-#u-nu-thai|tr|tr-TR|uk|uk-UA|vi|vi-VN|zh|zh-CN|zh-HK|zh-SG|zh-TW)?</pattern>
+    </request-param>
+    <route-param qname="gtn:sitetype">
+      <value>group</value>
+    </route-param>
+    <path-param qname="gtn:path" encoding="preserve-path">
+      <pattern>.*</pattern>
+    </path-param>
+  </route>
 
   <route path="/">
 

--- a/services/plf-configuration/src/main/resources/conf/platform/configuration.xml
+++ b/services/plf-configuration/src/main/resources/conf/platform/configuration.xml
@@ -68,16 +68,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                   <string>portal</string>
                </value>
                <value>
-                  <string>exoadmin</string>
-               </value>
-               <value>
                   <string>rest</string>
-               </value>
-               <value>
-                  <string>web</string>
-               </value>
-               <value>
-                  <string>eXoResources</string>
                </value>
                <value>
                   <string>commons-extension</string>

--- a/webapps/plf-meeds-extension/src/main/webapp/META-INF/exo-conf/configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/META-INF/exo-conf/configuration.xml
@@ -28,6 +28,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <property name="exo.social.groups.portalConfig.metadata.importmode" value="${exo.social.groups.portalConfig.metadata.importmode:OVERWRITE}" />
         <property name="exo.social.portalConfig.profilePage.importmode" value="${exo.social.portalConfig.profilePage.importmode:MERGE}" />
         <property name="exo.social.portalConfig.metadata.importmode" value="${exo.social.portalConfig.metadata.importmode:OVERWRITE}" />
+        <property name="io.meeds.useWebuiResources" value="false" />
       </properties-param>
     </init-params>
   </component>


### PR DESCRIPTION
This change will:
* Disable instanciation of WebUI PortalComposer in Portal Pages for Meeds Package
* Delete inclusion of deleted `web.war`, `eXoResources.war` and `exoadmin.war` in Meeds package