### PR TITLE
feat: Delete Push notifications from default package - MEED-2062 - Meeds-io/meeds#900

### DIFF
--- a/packaging/plf-community-tomcat-standalone/pom.xml
+++ b/packaging/plf-community-tomcat-standalone/pom.xml
@@ -93,12 +93,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.addons.push-notifications</groupId>
-      <artifactId>exo-push-notifications-addon-packaging</artifactId>
-      <type>zip</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.addons.app-center</groupId>
       <artifactId>app-center-packaging</artifactId>
       <type>zip</type>
@@ -357,9 +351,6 @@
                 </exec>
                 <exec dir="${project.basedir}" executable="${project.build.directory}/${project.build.finalName}/${project.build.finalName}/addon${addon.manager.extension}" failonerror="true">
                   <arg line="install ${addon.exo.app-center.id}:${addon.exo.app-center.version}  --catalog=file://${project.build.directory}/local-catalog/meeds-distrib-catalog.json" />
-                </exec>
-                <exec dir="${project.basedir}" executable="${project.build.directory}/${project.build.finalName}/${project.build.finalName}/addon${addon.manager.extension}" failonerror="true">
-                  <arg line="install ${addon.exo.push-notifications.id}:${addon.exo.push-notifications.version}  --catalog=file://${project.build.directory}/local-catalog/meeds-distrib-catalog.json" />
                 </exec>
                 <exec dir="${project.basedir}" executable="${project.build.directory}/${project.build.finalName}/${project.build.finalName}/addon${addon.manager.extension}" failonerror="true">
                   <arg line="install ${addon.exo.notes.id}:${addon.exo.notes.version}  --catalog=file://${project.build.directory}/local-catalog/meeds-distrib-catalog.json" />

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <addon.exo.wallet.version>2.5.x-SNAPSHOT</addon.exo.wallet.version>
     <addon.exo.gamification.id>meeds-gamification</addon.exo.gamification.id>
     <addon.exo.gamification.version>2.5.x-SNAPSHOT</addon.exo.gamification.version>
-    <addon.exo.push-notifications.id>meeds-push-notifications</addon.exo.push-notifications.id>
-    <addon.exo.push-notifications.version>2.5.x-SNAPSHOT</addon.exo.push-notifications.version>
     <addon.exo.app-center.id>meeds-app-center</addon.exo.app-center.id>
     <addon.exo.app-center.version>2.5.x-SNAPSHOT</addon.exo.app-center.version>
     <addon.exo.notes.id>meeds-notes</addon.exo.notes.id>
@@ -133,13 +131,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>org.exoplatform.addons.gamification</groupId>
         <artifactId>gamification-packaging</artifactId>
         <version>${addon.exo.gamification.version}</version>
-        <type>zip</type>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.addons.push-notifications</groupId>
-        <artifactId>exo-push-notifications-addon-packaging</artifactId>
-        <version>${addon.exo.push-notifications.version}</version>
         <type>zip</type>
         <scope>provided</scope>
       </dependency>


### PR DESCRIPTION
This change will delete push-notifications addon from default package to avoid displaying it as enabled notification configuration while it can't be enabled without further configuration steps.