### PR TITLE
fix: Improve security for rememberme feature - EXO-59675 - meeds-io/MIPs#69

### DIFF
--- a/packaging/plf-tomcat-resources/src/main/resources/conf/jaas.conf
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/jaas.conf
@@ -2,6 +2,9 @@ gatein-domain {
   org.exoplatform.web.login.FilterDisabledLoginModule required
     portalContainerName=portal
     realmName=gatein-domain;
+  org.exoplatform.web.login.RememberMeLoginModule required
+    portalContainerName=portal
+    realmName=gatein-domain;
   io.meeds.oauth.jaas.OAuthLoginModule required
     portalContainerName=portal
     realmName=gatein-domain;


### PR DESCRIPTION
Before this fix, user password was encoded in the rememberme token, with a reversible function This commit update the rememberme to not use the user password in the rememberme token

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - Meeds-io/MIPs#1234
or
fix: Fix TITLE - MEED-XXXX - Meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
