### PR TITLE
feat: Disable Site Layout Share with group and spaces Portals - MEED-2505 - Meeds-io/MIPs#84

### DIFF
--- a/webapps/plf-meeds-extension/src/main/webapp/META-INF/exo-conf/configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/META-INF/exo-conf/configuration.xml
@@ -31,6 +31,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <property name="io.meeds.useWebuiResources" value="false" />
         <property name="exo.feature.PostToNetwork.enabled" value="${exo.feature.PostToNetwork.enabled:true}" />
         <property name="exo.feature.SNVFullPageAccess.enabled" value="${exo.feature.SNVFullPageAccess.enabled:false}" />
+        <property name="exo.portal.dynamic.group.layout.useCurrentPortalLayout" value="false" />
+        <property name="exo.portal.dynamic.user.layout.useCurrentPortalLayout" value="false" />
+        <property name="exo.portal.dynamic.space.layout.useCurrentPortalLayout" value="false" />
       </properties-param>
     </init-params>
   </component>


### PR DESCRIPTION
Prior to this change, when displaying the public site and right after display a group or space, the Public Portal Layout is displayed as well under the TopBar (Shared layout). This change will disable the dynamic layout share with group, user and space layouts for Meeds package.