### PR TITLE
feat: Public site Page and Navigation visibility - MEED-2811 - Meeds-io/MIPs#100

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-configuration.xml
@@ -133,4 +133,19 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin>
+      <name>meeds.settings.access.type.modified</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.portal.security.listener.PortalRegistrationUpdateListener</type>
+      <init-params>
+        <values-param>
+          <name>managed-pages</name>
+          <value>overview/actions</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/pages.xml
@@ -81,7 +81,8 @@
         </container>
         <container
           template="system:/groovy/portal/webui/container/UIContainer.gtmpl"
-          cssClass="mb-5">
+          cssClass="mb-5"
+          profiles="notes">
           <access-permissions>Everyone</access-permissions>
           <portlet-application>
             <portlet>
@@ -100,54 +101,62 @@
             <show-application-state>false</show-application-state>
           </portlet-application>
         </container>
-        <container
-          template="system:/groovy/portal/webui/container/UIVRowContainer.gtmpl"
-          cssClass="mb-5">
+        <container template="system:/groovy/portal/webui/container/UIOpenRegistrationContainer.gtmpl">
           <access-permissions>Everyone</access-permissions>
           <container
-            id="TopChallengersContainer"
-            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
-            cssClass="col col-sm-12 col-md-6 col-lg-4">
+            id="gamificationWidgets"
+            template="system:/groovy/portal/webui/container/UIVRowContainer.gtmpl"
+            cssClass="mb-5"
+            profiles="gamification">
             <access-permissions>Everyone</access-permissions>
-            <portlet-application>
-              <portlet>
-                <application-ref>gamification-portlets</application-ref>
-                <portlet-ref>topChallengers</portlet-ref>
-              </portlet>
-              <title>Top Challengers</title>
+            <container
+              id="TopChallengersContainer"
+              template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+              cssClass="col col-sm-12 col-md-6 col-lg-4"
+              profiles="gamification">
               <access-permissions>Everyone</access-permissions>
-              <show-info-bar>false</show-info-bar>
-            </portlet-application>
-          </container>
-          <container
-            id="ChanllengesOverviewContainer"
-            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
-            cssClass="col col-sm-12 col-md-6 col-lg-4">
-            <access-permissions>Everyone</access-permissions>
-            <portlet-application>
-              <portlet>
-                <application-ref>gamification-portlets</application-ref>
-                <portlet-ref>challengesOverview</portlet-ref>
-              </portlet>
-              <title>Challenges Overview</title>
+              <portlet-application>
+                <portlet>
+                  <application-ref>gamification-portlets</application-ref>
+                  <portlet-ref>topChallengers</portlet-ref>
+                </portlet>
+                <title>Top Challengers</title>
+                <access-permissions>Everyone</access-permissions>
+                <show-info-bar>false</show-info-bar>
+              </portlet-application>
+            </container>
+            <container
+              id="ChanllengesOverviewContainer"
+              template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+              cssClass="col col-sm-12 col-md-6 col-lg-4"
+              profiles="gamification">
               <access-permissions>Everyone</access-permissions>
-              <show-info-bar>false</show-info-bar>
-            </portlet-application>
-          </container>
-          <container
-            id="ProgramsOverviewContainer"
-            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
-            cssClass="col col-sm-12 col-md-6 col-lg-4">
-            <access-permissions>Everyone</access-permissions>
-            <portlet-application>
-              <portlet>
-                <application-ref>gamification-portlets</application-ref>
-                <portlet-ref>programsOverview</portlet-ref>
-              </portlet>
-              <title>Programs Overview</title>
+              <portlet-application>
+                <portlet>
+                  <application-ref>gamification-portlets</application-ref>
+                  <portlet-ref>challengesOverview</portlet-ref>
+                </portlet>
+                <title>Challenges Overview</title>
+                <access-permissions>Everyone</access-permissions>
+                <show-info-bar>false</show-info-bar>
+              </portlet-application>
+            </container>
+            <container
+              id="ProgramsOverviewContainer"
+              template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+              cssClass="col col-sm-12 col-md-6 col-lg-4"
+              profiles="gamification">
               <access-permissions>Everyone</access-permissions>
-              <show-info-bar>false</show-info-bar>
-            </portlet-application>
+              <portlet-application>
+                <portlet>
+                  <application-ref>gamification-portlets</application-ref>
+                  <portlet-ref>programsOverview</portlet-ref>
+                </portlet>
+                <title>Programs Overview</title>
+                <access-permissions>Everyone</access-permissions>
+                <show-info-bar>false</show-info-bar>
+              </portlet-application>
+            </container>
           </container>
         </container>
       </container>
@@ -160,18 +169,21 @@
     <access-permissions>Everyone</access-permissions>
     <edit-permission>*:/platform/administrators</edit-permission>
     <hide-shared-layout>true</hide-shared-layout>
-    <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+    <container template="system:/groovy/portal/webui/container/UIOpenRegistrationContainer.gtmpl">
       <access-permissions>Everyone</access-permissions>
-      <portlet-application>
-        <portlet>
-          <application-ref>gamification-portlets</application-ref>
-          <portlet-ref>EngagementCenterActions</portlet-ref>
-        </portlet>
-        <title>Gamification Actions</title>
+      <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
         <access-permissions>Everyone</access-permissions>
-        <show-info-bar>false</show-info-bar>
-        <show-application-state>false</show-application-state>
-      </portlet-application>
+        <portlet-application>
+          <portlet>
+            <application-ref>gamification-portlets</application-ref>
+            <portlet-ref>EngagementCenterActions</portlet-ref>
+          </portlet>
+          <title>Gamification Actions</title>
+          <access-permissions>Everyone</access-permissions>
+          <show-info-bar>false</show-info-bar>
+          <show-application-state>false</show-application-state>
+        </portlet-application>
+      </container>
     </container>
   </page>
 


### PR DESCRIPTION
This change will introduce a new Listener Event configuration to update 'actions' page visibility switch Hub Access Type. In addition, this change will use the 'Behavior container' of name 'UIOpenRegistrationContainer.gtmpl' to hide Gamification widgets from Public page when the Hub access isn't Open.