### PR TITLE
feat: Define Properties for Site names - MEED-2811 - Meeds-io/MIPs#100

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-configuration.xml
@@ -24,6 +24,33 @@
   xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
 
+  <component>
+    <key>SitesConfigProperties</key>
+    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+    <init-params>
+      <properties-param>
+        <name>SitesConfigProperties</name>
+        <property name="io.meeds.engagementSite.name" value="${io.meeds.engagementSite.name:meeds}" />
+        <property name="io.meeds.myCraftSite.name" value="${io.meeds.myCraftSite.name:meeds}" />
+      </properties-param>
+    </init-params>
+  </component>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.groovyscript.text.TemplateService</target-component>
+    <component-plugin>
+      <name>UIPortalApplication-head</name>
+      <set-method>addTemplateExtension</set-method>
+      <type>org.exoplatform.groovyscript.text.TemplateExtensionPlugin</type>
+      <init-params>
+        <values-param>
+          <name>templates</name>
+          <value>war:/groovy/webui/UISitesPortalApplicationHead.gtmpl</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
   <external-component-plugins>
     <target-component>org.exoplatform.portal.config.UserPortalConfigService</target-component>
     <component-plugin>

--- a/webapps/plf-sites-extension/src/main/webapp/groovy/webui/UISitesPortalApplicationHead.gtmpl
+++ b/webapps/plf-sites-extension/src/main/webapp/groovy/webui/UISitesPortalApplicationHead.gtmpl
@@ -1,0 +1,13 @@
+<%
+  import org.exoplatform.commons.utils.PropertyManager;
+
+  def rcontext = _ctx.getRequestContext() ;
+  String engagementSite = PropertyManager.getProperty('io.meeds.engagementSite.name');
+  String myCraftSite = PropertyManager.getProperty('io.meeds.myCraftSite.name');
+%>
+<script type="text/javascript" id="socialHeadScripts">
+  eXo.env.portal.portalName = "<%=rcontext.getPortalOwner()%>";
+  eXo.env.portal.defaultPortal = "<%=rcontext.getDefaultPortal()%>";
+  eXo.env.portal.engagementSiteName = "<%=engagementSite%>" ;
+  eXo.env.portal.myCraftSiteName = "<%=myCraftSite%>" ;
+</script>


### PR DESCRIPTION
This change will add JS variables to define site names:
- My Craft site: which will have 'Achivements' and 'Wallet' pages
- Engagement Site: which will have 'Actions', 'Programs' and 'Perkstore' pages
- Default Site: all other applications will be added and referenced from default site which may be different from public site.