### PR TITLE
fix: Fix sites extension submodule version after Meeds-io/MIPs#84 merge

### DIFF
--- a/webapps/plf-sites-extension/pom.xml
+++ b/webapps/plf-sites-extension/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-webapps</artifactId>
-    <version>1.5.x-SNAPSHOT</version>
+    <version>1.5.x-exo-SNAPSHOT</version>
   </parent>
   <artifactId>plf-sites-extension</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
Prior to this change, a git reverse rebase was performed. A commit was applied and contained a standard `develop` branch version. This rebase led to incorrect configuration of submodule versions.