### PR TITLE
feat: Centralize Administration Site definition - MEED-3007 - Meeds-io/meeds#1327

### DIFF
--- a/translations.properties
+++ b/translations.properties
@@ -24,3 +24,4 @@ webui.properties=webapps/plf-meeds-extension/src/main/resources/locale/portal/we
 Login.properties=webapps/plf-meeds-extension/src/main/resources/locale/portlet/Login_en.properties
 public.properties=webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/public_en.properties
 global.properties=webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/global_en.properties
+administration.properties=webapps/plf-meeds-extension/src/main/resources/locale/navigation/portal/administration_en.properties

--- a/webapps/plf-meeds-extension/src/main/webapp/META-INF/exo-conf/configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/META-INF/exo-conf/configuration.xml
@@ -25,15 +25,16 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <init-params>
       <properties-param>
         <name>MeedsPortalConfigProperties</name>
-        <property name="exo.social.groups.portalConfig.metadata.importmode" value="${exo.social.groups.portalConfig.metadata.importmode:OVERWRITE}" />
-        <property name="exo.social.portalConfig.metadata.importmode" value="${exo.social.portalConfig.metadata.importmode:OVERWRITE}" />
-        <property name="io.meeds.portalConfig.metadata.importmode" value="${io.meeds.portalConfig.metadata.importmode:OVERWRITE}" />
-        <property name="io.meeds.groups.portalConfig.metadata.importmode" value="${io.meeds.groups.portalConfig.metadata.importmode:OVERWRITE}" />
+        <!-- global site -->
+        <property name="io.meeds.portalConfig.metadata.importmode" value="OVERWRITE" />
+        <!-- group sites -->
+        <property name="io.meeds.groups.portalConfig.metadata.importmode" value="OVERWRITE" />
+        <!-- administration site -->
+        <property name="io.meeds.administration.portalConfig.metadata.importmode" value="MERGE" />
+        <!-- Disable WebUI for Meeds -->
         <property name="io.meeds.useWebuiResources" value="false" />
+        <!-- Enable Posting to network -->
         <property name="exo.feature.PostToNetwork.enabled" value="${exo.feature.PostToNetwork.enabled:true}" />
-        <property name="exo.portal.dynamic.group.layout.useCurrentPortalLayout" value="false" />
-        <property name="exo.portal.dynamic.user.layout.useCurrentPortalLayout" value="false" />
-        <property name="exo.portal.dynamic.space.layout.useCurrentPortalLayout" value="false" />
       </properties-param>
     </init-params>
   </component>

--- a/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/administration_en.properties
+++ b/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/administration_en.properties
@@ -1,0 +1,34 @@
+#
+# This file is part of the Meeds project (https://meeds.io/).
+# Copyright (C) 2023 Meeds Association
+# contact@meeds.io
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+portal.administration.home=Platform settings
+portal.administration.general=General
+portal.administration.organisation=Organisation
+portal.administration.recognition=Recognition
+portal.administration.applications=Applications
+portal.administration.security=Security
+portal.administration.legacy=Legacy
+portal.administration.users=Users
+portal.administration.groups=Groups
+portal.administration.profile=Profile
+portal.administration.spaces=Spaces
+portal.administration.mainsettings=Main Settings
+portal.administration.notification=Notifications
+portal.administration.wallet=Wallet
+portal.administration.reward=Reward
+portal.administration.perks=Perks
+portal.administration.kudos=Kudos
+portal.administration.appCenterAdminSetup=Applications center

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/general/portal/administration/navigation.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/general/portal/administration/navigation.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<node-navigation
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_6 http://www.gatein.org/xml/ns/gatein_objects_1_6"
+        xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_6">
+  <priority>3</priority>
+
+  <page-nodes>
+    <node>
+      <name>home</name>
+      <label>#{portal.administration.home}</label>
+      <icon>fas fa-cog</icon>
+      <node>
+        <name>general</name>
+        <label>#{portal.administration.general}</label>
+        <icon>fas fa-cog</icon>
+        <node>
+          <name>mainsettings</name>
+          <label>#{portal.administration.mainsettings}</label>
+          <icon>fas fa-cogs</icon>
+          <page-reference>portal::administration::generalSettings</page-reference>
+        </node>
+        <node>
+          <name>notification</name>
+          <label>#{portal.administration.notification}</label>
+          <icon>fas fa-bell</icon>
+          <page-reference>portal::administration::notification</page-reference>
+        </node>
+        <node>
+          <name>applicationsCenter</name>
+          <label>#{portal.administration.appCenterAdminSetup}</label>
+          <icon>fas fa-list-alt</icon>
+          <page-reference>portal::administration::appCenterAdminSetup</page-reference>
+        </node>
+      </node>
+    </node>
+  </page-nodes>
+</node-navigation>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/general/portal/administration/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/general/portal/administration/pages.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<page-set xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_objects_1_8 http://www.exoplatform.org/xml/ns/gatein_objects_1_8"
+          xmlns="http://www.exoplatform.org/xml/ns/gatein_objects_1_8">
+  <page>
+    <name>generalSettings</name>
+    <title>General Settings</title>
+    <access-permissions>*:/platform/administrators</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>social-portlet</application-ref>
+            <portlet-ref>GeneralSettings</portlet-ref>
+        </portlet>
+        <title>General Settings Portlet</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
+  <page>
+    <name>notification</name>
+    <title>Notifications Administration</title>
+    <access-permissions>*:/platform/administrators</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+        <portlet-application>
+          <portlet>
+            <application-ref>social-portlet</application-ref>
+            <portlet-ref>NotificationAdministration</portlet-ref>
+          </portlet>
+          <title>Notifications Administration</title>
+          <access-permissions>Everyone</access-permissions>
+            <show-info-bar>false</show-info-bar>
+            <show-application-state>false</show-application-state>
+            <show-application-mode>false</show-application-mode>
+        </portlet-application>
+    </container>
+  </page>
+
+  <page profiles="app-center">
+    <name>appCenterAdminSetup</name>
+    <title>App center admin setup</title>
+    <access-permissions>*:/platform/administrators</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>app-center</application-ref>
+          <portlet-ref>AppCenterAdminSetupPortlet</portlet-ref>
+          <preferences>
+            <preference>
+              <name>pageSize</name>
+              <value>10</value>
+              <read-only>false</read-only>
+            </preference>
+          </preferences>
+        </portlet>
+        <title>App Center Admin Setup</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
+</page-set>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/organisation/portal/administration/navigation.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/organisation/portal/administration/navigation.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<node-navigation
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_6 http://www.gatein.org/xml/ns/gatein_objects_1_6"
+        xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_6">
+  <priority>3</priority>
+
+  <page-nodes>
+    <node>
+      <name>home</name>
+      <label>#{portal.administration.home}</label>
+      <icon>fas fa-cog</icon>
+      <node>
+        <name>organisation</name>
+        <label>#{portal.administration.organisation}</label>
+        <icon>fas fa-building</icon>
+        <node>
+          <name>users</name>
+          <label>#{portal.administration.users}</label>
+          <icon>fas fa-users-cog</icon>
+          <page-reference>portal::administration::usersManagement</page-reference>
+        </node>
+        <node>
+          <name>groups</name>
+          <label>#{portal.administration.groups}</label>
+          <icon>fab fa-simplybuilt</icon>
+          <page-reference>portal::administration::groupsManagement</page-reference>
+        </node>
+        <node>
+          <name>profile</name>
+          <label>#{portal.administration.profile}</label>
+          <icon>fas fa-user-cog</icon>
+          <page-reference>portal::administration::profileManagement</page-reference>
+        </node>
+        <node>
+          <name>spaces</name>
+          <label>#{portal.administration.spaces}</label>
+          <icon>fas fa-people-arrows</icon>
+          <page-reference>portal::administration::spacesAdministration</page-reference>
+        </node>
+      </node>
+    </node>
+  </page-nodes>
+</node-navigation>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/organisation/portal/administration/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/organisation/portal/administration/pages.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<page-set xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_objects_1_8 http://www.exoplatform.org/xml/ns/gatein_objects_1_8"
+          xmlns="http://www.exoplatform.org/xml/ns/gatein_objects_1_8">
+  <page>
+    <name>usersManagement</name>
+    <title>Users Management</title>
+    <access-permissions>*:/platform/administrators;*:/platform/delegated</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>social-portlet</application-ref>
+          <portlet-ref>IDMUsersManagement</portlet-ref>
+        </portlet>
+        <title>Users Management</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+        <show-application-state>false</show-application-state>
+      </portlet-application>
+    </container>
+  </page>
+  <page>
+    <name>groupsManagement</name>
+    <title>Groups Management</title>
+    <access-permissions>*:/platform/administrators</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>social-portlet</application-ref>
+          <portlet-ref>IDMGroupsManagement</portlet-ref>
+        </portlet>
+        <title>Groups Management</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+        <show-application-state>false</show-application-state>
+      </portlet-application>
+    </container>
+  </page>
+  <page>
+    <name>profileManagement</name>
+    <title>Profile Settings Management</title>
+    <access-permissions>*:/platform/administrators</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>social-portlet</application-ref>
+          <portlet-ref>ProfileSettingsPortlet</portlet-ref>
+        </portlet>
+        <title>Profile Settings Management</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+        <show-application-state>false</show-application-state>
+      </portlet-application>
+    </container>
+  </page>
+  <page>
+    <name>spacesAdministration</name>
+    <title>Spaces Administration</title>
+    <access-permissions>*:/platform/administrators</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <show-max-window>false</show-max-window>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>social-portlet</application-ref>
+          <portlet-ref>SpacesAdministration</portlet-ref>
+        </portlet>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
+</page-set>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/recognition/portal/administration/navigation.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/recognition/portal/administration/navigation.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<node-navigation
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_6 http://www.gatein.org/xml/ns/gatein_objects_1_6"
+        xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_6">
+  <priority>3</priority>
+
+  <page-nodes>
+    <node>
+      <name>home</name>
+      <label>#{portal.administration.home}</label>
+      <icon>fas fa-cog</icon>
+      <node>
+        <name>recognition</name>
+        <label>#{portal.administration.recognition}</label>
+        <icon>fas fa-trophy</icon>
+        <node>
+          <name>connectors</name>
+          <label>#{portal.administration.connectors}</label>
+          <icon>fas fa-plug</icon>
+          <page-reference>portal::administration::gamificationConnectorsAdministration</page-reference>
+        </node>
+        <node>
+          <name>wallet</name>
+          <label>#{portal.administration.wallet}</label>
+          <icon>fas fa-wallet</icon>
+          <page-reference>portal::administration::walletAdministration</page-reference>
+        </node>
+        <node>
+          <name>reward</name>
+          <label>#{portal.administration.reward}</label>
+          <icon>fas fa-coins</icon>
+          <page-reference>portal::administration::rewardAdministration</page-reference>
+        </node>
+        <node>
+          <name>perks</name>
+          <label>#{portal.administration.perks}</label>
+          <icon>fas fa-shopping-cart</icon>
+          <page-reference>portal::administration::perkStoreAdministration</page-reference>
+        </node>
+        <node>
+          <name>kudos</name>
+          <label>#{portal.administration.kudos}</label>
+          <icon>fas fa-award</icon>
+          <page-reference>portal::administration::kudosAdministration</page-reference>
+        </node>
+        <node>
+          <name>badges</name>
+          <label>#{portal.administration.badges}</label>
+          <icon>fas fa-graduation-cap</icon>
+          <page-reference>portal::administration::gamificationBadgesAdministration</page-reference>
+        </node>
+      </node>
+    </node>
+  </page-nodes>
+</node-navigation>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/recognition/portal/administration/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/administration-navigation/recognition/portal/administration/pages.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<page-set xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_objects_1_11 http://www.exoplatform.org/xml/ns/gatein_objects_1_11"
+          xmlns="http://www.exoplatform.org/xml/ns/gatein_objects_1_11">
+  <page profiles="gamification">
+    <name>gamificationConnectorsAdministration</name>
+    <title>Gamification Connectors Administration</title>
+    <access-permissions>*:/platform/rewarding</access-permissions>
+    <edit-permission>manager:/platform/rewarding</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl"
+               cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>gamification-portlets</application-ref>
+          <portlet-ref>ConnectorAdminSettings</portlet-ref>
+        </portlet>
+        <title>Gamification Connectors Administration</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
+
+  <page profiles="gamification">
+    <name>gamificationBadgesAdministration</name>
+    <title>Gamification Badges Administration</title>
+    <access-permissions>*:/platform/rewarding</access-permissions>
+    <edit-permission>manager:/platform/rewarding</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl"
+               cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>gamification-portlets</application-ref>
+          <portlet-ref>GamificationManageBadges</portlet-ref>
+        </portlet>
+        <title>Gamification Manage Badges</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
+
+  <page profiles="perk-store">
+    <name>perkStoreAdministration</name>
+    <title>perk store administration</title>
+    <access-permissions>*:/platform/rewarding</access-permissions>
+    <edit-permission>manager:/platform/rewarding</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>perk-store</application-ref>
+          <portlet-ref>PerkStoreAdmin</portlet-ref>
+        </portlet>
+        <title>perk store administration</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
+
+  <page profiles="kudos">
+    <name>kudosAdministration</name>
+    <title>Kudo administration</title>
+    <access-permissions>*:/platform/rewarding</access-permissions>
+    <edit-permission>manager:/platform/rewarding</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>kudos</application-ref>
+          <portlet-ref>KudosAdmin</portlet-ref>
+        </portlet>
+        <title>Kudos administration</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
+
+  <page profiles="wallet">
+    <name>walletAdministration</name>
+    <title>Wallet adminsitration</title>
+    <access-permissions>*:/platform/rewarding</access-permissions>
+    <edit-permission>manager:/platform/rewarding</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>wallet</application-ref>
+          <portlet-ref>WalletAdmin</portlet-ref>
+        </portlet>
+        <title>Wallet adminsitration</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
+
+  <page profiles="wallet">
+    <name>rewardAdministration</name>
+    <title>Reward administration</title>
+    <access-permissions>*:/platform/rewarding</access-permissions>
+    <edit-permission>manager:/platform/rewarding</edit-permission>
+    <container id="singlePageApplicationContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+      <access-permissions>Everyone</access-permissions>
+      <portlet-application>
+        <portlet>
+          <application-ref>wallet</application-ref>
+          <portlet-ref>RewardAdmin</portlet-ref>
+        </portlet>
+        <title>Reward administration</title>
+        <access-permissions>Everyone</access-permissions>
+        <show-info-bar>false</show-info-bar>
+      </portlet-application>
+    </container>
+  </page>
+</page-set>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-configuration.xml
@@ -116,6 +116,138 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <!-- Split navigation configurations to be loaded separately -->
+    <component-plugin>
+      <name>public.portal.configuration</name>
+      <set-method>initListener</set-method>
+      <type>org.exoplatform.portal.config.NewPortalConfigListener</type>
+      <priority>10</priority>
+      <init-params>
+        <object-param>
+          <name>portal.configuration</name>
+          <object type="org.exoplatform.portal.config.NewPortalConfig">
+            <field name="predefinedOwner">
+              <collection type="java.util.HashSet">
+                <value>
+                  <string>administration</string>
+                </value>
+              </collection>
+            </field>
+            <field name="ownerType">
+              <string>portal</string>
+            </field>
+            <field name="location">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="override">
+              <boolean>${io.meeds.administration.portalConfig.metadata.override:true}</boolean>
+            </field>
+            <field name="importMode">
+              <string>${io.meeds.administration.portalConfig.metadata.importmode:insert}</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <!-- administration/general -->
+    <component-plugin>
+      <name>public.portal.configuration</name>
+      <set-method>initListener</set-method>
+      <type>org.exoplatform.portal.config.NewPortalConfigListener</type>
+      <priority>20</priority>
+      <init-params>
+        <object-param>
+          <name>portal.configuration</name>
+          <object type="org.exoplatform.portal.config.NewPortalConfig">
+            <field name="predefinedOwner">
+              <collection type="java.util.HashSet">
+                <value>
+                  <string>administration</string>
+                </value>
+              </collection>
+            </field>
+            <field name="ownerType">
+              <string>portal</string>
+            </field>
+            <field name="location">
+              <string>war:/conf/sites/administration-navigation/general/</string>
+            </field>
+            <field name="override">
+              <boolean>${io.meeds.administration.portalConfig.metadata.override:true}</boolean>
+            </field>
+            <field name="importMode">
+              <string>${io.meeds.administration.portalConfig.metadata.importmode:insert}</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <!-- administration/organisation -->
+    <component-plugin>
+      <name>public.portal.configuration</name>
+      <set-method>initListener</set-method>
+      <type>org.exoplatform.portal.config.NewPortalConfigListener</type>
+      <priority>30</priority>
+      <init-params>
+        <object-param>
+          <name>portal.configuration</name>
+          <object type="org.exoplatform.portal.config.NewPortalConfig">
+            <field name="predefinedOwner">
+              <collection type="java.util.HashSet">
+                <value>
+                  <string>administration</string>
+                </value>
+              </collection>
+            </field>
+            <field name="ownerType">
+              <string>portal</string>
+            </field>
+            <field name="location">
+              <string>war:/conf/sites/administration-navigation/organisation/</string>
+            </field>
+            <field name="override">
+              <boolean>${io.meeds.administration.portalConfig.metadata.override:true}</boolean>
+            </field>
+            <field name="importMode">
+              <string>${io.meeds.administration.portalConfig.metadata.importmode:insert}</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <!-- administration/recognition -->
+    <component-plugin>
+      <name>public.portal.configuration</name>
+      <set-method>initListener</set-method>
+      <type>org.exoplatform.portal.config.NewPortalConfigListener</type>
+      <priority>40</priority>
+      <init-params>
+        <object-param>
+          <name>portal.configuration</name>
+          <object type="org.exoplatform.portal.config.NewPortalConfig">
+            <field name="predefinedOwner">
+              <collection type="java.util.HashSet">
+                <value>
+                  <string>administration</string>
+                </value>
+              </collection>
+            </field>
+            <field name="ownerType">
+              <string>portal</string>
+            </field>
+            <field name="location">
+              <string>war:/conf/sites/administration-navigation/recognition/</string>
+            </field>
+            <field name="override">
+              <boolean>${io.meeds.administration.portalConfig.metadata.override:true}</boolean>
+            </field>
+            <field name="importMode">
+              <string>${io.meeds.administration.portalConfig.metadata.importmode:insert}</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+
+<portal-config
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_10 http://www.gatein.org/xml/ns/gatein_objects_1_10"
+        xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_10">
+  <portal-name>administration</portal-name>
+  <label>Platform settings</label>
+  <displayed>false</displayed>
+  <locale>en</locale>
+  <access-permissions>*:/platform/users</access-permissions>
+  <edit-permission>manager:/platform/administrators</edit-permission>
+  <properties>
+    <entry key="sessionAlive">onDemand</entry>
+    <entry key="showPortletInfo">0</entry>
+  </properties>
+  <portal-layout>
+    <container template="system:/groovy/portal/webui/container/UISimpleTableContainer.gtmpl">
+      <access-permissions>*:/platform/users</access-permissions>
+      <container template="system:/groovy/portal/webui/container/UIResponsiveColumnGroupContainer.gtmpl">
+        <container template="system:/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl" cssClass="administrationSiteVerticalMenuContainerClass">
+          <access-permissions>*:/platform/users</access-permissions>
+          <portlet-application>
+            <portlet>
+              <application-ref>social-portlet</application-ref>
+              <portlet-ref>VerticalMenu</portlet-ref>
+            </portlet>
+            <title>Site Vertical Menu</title>
+            <access-permissions>*:/platform/users</access-permissions>
+            <show-info-bar>false</show-info-bar>
+            <show-application-state>false</show-application-state>
+            <show-application-mode>false</show-application-mode>
+          </portlet-application>
+          </container>
+        <container template="system:/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl" cssClass="administrationSitePageBodyContainerClass">
+          <access-permissions>*:/platform/users</access-permissions>
+          <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
+            <access-permissions>*:/platform/users</access-permissions>
+            <portlet-application>
+              <portlet>
+                <application-ref>social-portlet</application-ref>
+                <portlet-ref>Breadcrumb</portlet-ref>
+              </portlet>
+              <title>Site Breadcrumb application</title>
+              <access-permissions>*:/platform/users</access-permissions>
+              <show-info-bar>false</show-info-bar>
+              <show-application-state>false</show-application-state>
+              <show-application-mode>false</show-application-mode>
+            </portlet-application>
+          </container>
+          <page-body> </page-body>
+        </container>
+      </container>
+    </container>
+  </portal-layout>
+</portal-config>


### PR DESCRIPTION
Prior to this change, the administration site layout was loaded from different addons. This change will centralize the site definition, as other sites, in Meeds to ease the reorder of navigations when needed and to ease its maintenance.