### PR TITLE
fix: Delete BreadCrumb container margins - MEED-3023 - Meeds-io/meeds#1349

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
@@ -34,7 +34,7 @@
     <entry key="showPortletInfo">0</entry>
   </properties>
   <portal-layout>
-    <container template="system:/groovy/portal/webui/container/UISimpleTableContainer.gtmpl">
+    <container template="system:/groovy/portal/webui/container/UISimpleTableContainer.gtmpl" cssClass="ma-0">
       <access-permissions>*:/platform/users</access-permissions>
       <container template="system:/groovy/portal/webui/container/UIResponsiveColumnGroupContainer.gtmpl">
         <container template="system:/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl" cssClass="administrationSiteVerticalMenuContainerClass">


### PR DESCRIPTION
This change will delete useless margin defined in `UISimpleColumnContainer`.