### PR TITLE
fix: Fix Access to Overview Banner on Old Instances - MEED-3099 - Meeds-io/meeds#1476

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -1860,4 +1860,150 @@
     </container>
   </page>
 
+  <page profiles="gamification">
+    <name>overview</name>
+    <title>Overview</title>
+    <access-permissions>Everyone</access-permissions>
+    <edit-permission>*:/platform/rewarding</edit-permission>
+    <container
+      id="meedsOverviewPage"
+      template="system:/groovy/portal/webui/container/UIContainer.gtmpl"
+      cssClass="VuetifyApp">
+      <access-permissions>Everyone</access-permissions>
+      <container
+        template="system:/groovy/portal/webui/container/UIContainer.gtmpl"
+        cssClass="v-application v-application--is-ltr v-application--wrap singlePageApplication">
+        <access-permissions>Everyone</access-permissions>
+        <container
+          id="overviewPage"
+          template="system:/groovy/portal/webui/container/UIVRowContainer.gtmpl">
+          <access-permissions>Everyone</access-permissions>
+          <container
+            id="overviewBannerContainer"
+            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+            cssClass="col-12 py-0">
+            <access-permissions>Everyone</access-permissions>
+            <portlet-application>
+              <portlet>
+                <application-ref>social-portlet</application-ref>
+                <portlet-ref>Image</portlet-ref>
+                <preferences>
+                  <preference>
+                    <name>name</name>
+                    <value>overivewPageBanner</value>
+                  </preference>
+                  <preference>
+                    <name>image-path</name>
+                    <value>war:/../images/pages/banner/dashboard-banner.png</value>
+                    <read-only>false</read-only>
+                  </preference>
+                </preferences>
+              </portlet>
+              <title>Banner</title>
+              <access-permissions>Everyone</access-permissions>
+              <show-info-bar>false</show-info-bar>
+              <show-application-state>false</show-application-state>
+            </portlet-application>
+          </container>
+          <container
+            id="LeaderboardContainer"
+            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+            cssClass="col col-sm-12 col-md-6 col-lg-4 py-0"
+            profiles="gamification">
+            <access-permissions>Everyone</access-permissions>
+            <portlet-application>
+              <portlet>
+                <application-ref>gamification-portlets</application-ref>
+                <portlet-ref>topChallengers</portlet-ref>
+              </portlet>
+              <title>Leaderboard</title>
+              <access-permissions>Everyone</access-permissions>
+              <show-info-bar>false</show-info-bar>
+            </portlet-application>
+          </container>
+          <container
+            id="ActionsOverviewContainer"
+            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+            cssClass="col col-sm-12 col-md-6 col-lg-4 py-0"
+            profiles="gamification">
+            <access-permissions>Everyone</access-permissions>
+            <portlet-application>
+              <portlet>
+                <application-ref>gamification-portlets</application-ref>
+                <portlet-ref>challengesOverview</portlet-ref>
+              </portlet>
+              <title>Actions overview</title>
+              <access-permissions>Everyone</access-permissions>
+              <show-info-bar>false</show-info-bar>
+            </portlet-application>
+          </container>
+          <container
+            id="ProgramsOverviewContainer"
+            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+            cssClass="col col-sm-12 col-md-6 col-lg-4 py-0"
+            profiles="gamification">
+            <access-permissions>Everyone</access-permissions>
+            <portlet-application>
+              <portlet>
+                <application-ref>gamification-portlets</application-ref>
+                <portlet-ref>programsOverview</portlet-ref>
+              </portlet>
+              <title>Programs Overview</title>
+              <access-permissions>Everyone</access-permissions>
+              <show-info-bar>false</show-info-bar>
+            </portlet-application>
+          </container>
+          <container
+            id="contributionsContainer"
+            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+            cssClass="col col-sm-12 col-md-6 col-lg-4 py-0"
+            profiles="gamification">
+            <access-permissions>Everyone</access-permissions>
+            <portlet-application>
+              <portlet>
+                <application-ref>gamification-portlets</application-ref>
+                <portlet-ref>myContributions</portlet-ref>
+              </portlet>
+              <title>User Contributions</title>
+              <access-permissions>Everyone</access-permissions>
+              <show-info-bar>false</show-info-bar>
+            </portlet-application>
+          </container>
+          <container
+            id="ReputationContainer"
+            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+            cssClass="col col-sm-12 col-md-6 col-lg-4 py-0"
+            profiles="gamification">
+            <access-permissions>Everyone</access-permissions>
+            <portlet-application>
+              <portlet>
+                <application-ref>gamification-portlets</application-ref>
+                <portlet-ref>myReputation</portlet-ref>
+              </portlet>
+              <title>User reputation</title>
+              <access-permissions>Everyone</access-permissions>
+              <show-info-bar>false</show-info-bar>
+            </portlet-application>
+          </container>
+          <container
+            id="RewardsContainer"
+            template="system:/groovy/portal/webui/container/UIVColContainer.gtmpl"
+            cssClass="col col-sm-12 col-md-6 col-lg-4 py-0"
+            profiles="wallet">
+            <access-permissions>Everyone</access-permissions>
+            <portlet-application>
+              <portlet>
+                <application-ref>gamification-portlets</application-ref>
+                <portlet-ref>myRewards</portlet-ref>
+              </portlet>
+              <title>User rewards</title>
+              <access-permissions>Everyone</access-permissions>
+              <show-info-bar>false</show-info-bar>
+            </portlet-application>
+          </container>
+        </container>
+      </container>
+    </container>
+  </page>
+
 </page-set>


### PR DESCRIPTION
Prior to this change, old instances having Overview Banner in CI/CD mode, where we had the Image Portlet into it, are facing an access permission problem to banner images of new Dashboard page. This is due to the fact that 'Image' portlet is instantiated in both pages using the same id (deleted one = 'overview' and new one = 'dashboard'). When the page is deleted from instance, the access permission of the given setting is empty and thus accessible by content contributors only. This change will create again the global overview page to avoid redefining an id for 'dashboard' page which will make the previously chosen image data lost.