### PR TITLE
feat: Cleanup Dependencies to rely on Spring Dependencies Tree - Meeds-io/MIPs#57

### DIFF
--- a/packaging/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
+++ b/packaging/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
@@ -27,6 +27,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <includes>
         <include>*:*:jar</include>
       </includes>
+      <!-- Excluded Transitive dependencies to not include in Tomcat Runtime Environment -->
       <excludes>
         <!-- No Apache Tomcat artifacts have to be added in the packaging -->
         <exclude>org.apache.tomcat:*</exclude>
@@ -54,10 +55,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <!-- Servlet API are provided by the app server. It shouldn't come from a project -->
         <exclude>jakarta.servlet:*</exclude>
         <exclude>jakarta.servlet.jsp:*</exclude>
+        <exclude>jakarta.servlet*:*</exclude>
         <!-- Incompatible Servlet API -->
-        <exclude>javax.servlet:*</exclude>
+        <exclude>jakarta.servlet:*</exclude>
         <!-- Incompatible JSP API -->
-        <exclude>javax.servlet.jsp:*</exclude>
+        <exclude>jakarta.servlet.jsp:*</exclude>
         <!-- Avoid javax.websocket-api.jar should be provided by container -->
         <exclude>*:javax.websocket-api</exclude>
         <!-- Incompatible Portlet API -->
@@ -70,12 +72,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <exclude>org.jmock:*</exclude>
         <exclude>jmock:*</exclude>
         <exclude>org.mockito:*</exclude>
+        <exclude>commons-dbcp:commons-dbcp</exclude>
         <!-- These old versions of jdom are in conflict with new ones under org.jdom:* -->
         <exclude>jdom:*</exclude>
-        <!-- These artifacts are in conflict with others ones under xpp3:xpp3 -->
-        <exclude>xpp3:xpp3_min</exclude>
-        <!-- DEP-105: These artifacts are in conflict with others ones under org.ogce:xpp3 -->
-        <exclude>xpp3:xpp3</exclude>
         <!-- These artifact is in conflict with ones under commons-beanutils:commons-beanutils -->
         <exclude>commons-beanutils:commons-beanutils-core</exclude>
         <!-- This artifact is in conflict with the one under org.jboss.logging:jboss-logging -->
@@ -91,6 +90,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <exclude>org.jboss.javaee:jboss-transaction-api</exclude>
         <exclude>org.jboss.spec.javax.transaction:*</exclude>
         <exclude>org.ow2.spec.ee:ow2-jta-1.1-spec</exclude>
+        <!-- Unused dependencies on runtime -->
+        <exclude>xerces:xercesImpl</exclude>
+        <exclude>xpp3:xpp3_min</exclude>
+        <exclude>xpp3:xpp3</exclude>
+        <exclude>org.ogce:xpp3</exclude>
         <!-- PLF-4528 / CAL-148 : Conflict with com.totsp.feedpod:itunes-com-podcast -->
         <exclude>rome:modules:*</exclude>
         <!-- this is a build resource -->

--- a/packaging/plf-dependencies/pom.xml
+++ b/packaging/plf-dependencies/pom.xml
@@ -128,7 +128,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </exclusion>
         <exclusion>
           <groupId>io.swagger.core.v3</groupId>
-          <artifactId>swagger-annotations</artifactId>
+          <artifactId>swagger-annotations-jakarta</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.projectlombok</groupId>

--- a/packaging/plf-tomcat-resources/src/main/resources/bin/setenv.sh
+++ b/packaging/plf-tomcat-resources/src/main/resources/bin/setenv.sh
@@ -254,6 +254,11 @@ CATALINA_OPTS="$CATALINA_OPTS -Dexo.files.storage.dir=\"${EXO_DATA_DIR}/files\""
 
 # Logback configuration file
 CATALINA_OPTS="$CATALINA_OPTS -Dlogback.configurationFile=\"${EXO_LOGS_LOGBACK_CONFIG_FILE}\""
+CATALINA_OPTS="$CATALINA_OPTS -Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
+CATALINA_OPTS="$CATALINA_OPTS -Dliquibase.showBanner=false"
+CATALINA_OPTS="$CATALINA_OPTS -Dliquibase.command.showSummary=OFF"
+CATALINA_OPTS="$CATALINA_OPTS -Dliquibase.hub.mode=OFF"
+CATALINA_OPTS="$CATALINA_OPTS -Dliquibase.logLevel=WARNING"
 
 # Define the XML Parser depending on the JVM vendor
 if [ "${EXO_JVM_VENDOR}" = "IBM" ]; then

--- a/packaging/plf-tomcat-resources/src/main/resources/conf/logback.xml
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/logback.xml
@@ -89,6 +89,8 @@ For more details see : http://logback.qos.ch/manual/configuration.html
   <logger name="org.apache.catalina.realm.JAASRealm" level="ERROR"/>
   <logger name="org.cometd.server.websocket" level="WARN" />
   <logger name="org.cometd.oort.Oort" level="ERROR" />
+  <logger name="org.picketlink" level="WARN" />
+  <logger name="liquibase" level="WARN" />
   <if condition='"true".equals(property("EXO_LOGS_DISPLAY_CONSOLE"))'>
     <then>
       <!-- This is activated by default on unix like systems -->

--- a/pom.xml
+++ b/pom.xml
@@ -354,13 +354,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                       <message>There are some unwanted dependencies in the dependency tree. Find them with "mvn dependency:tree -Dverbose -Dincludes=groupId:artifactId:version" and remove them at the furthest dependency level in the dependency tree</message>
                       <searchTransitive>true</searchTransitive>
                       <excludes>
-                        <!-- No Apache Tomcat artifacts have to be added in the packaging -->
-                        <exclude>org.apache.tomcat:*</exclude>
                         <!-- Ant and related aren't really useful for us at runtime -->
                         <exclude>org.apache.ant:*</exclude>
                         <exclude>org.apache.axis:axis-ant:*</exclude>
-                        <!-- commons-logging is forbidden and must be replaced by org.slf4j:jcl-over-slf4j -->
-                        <exclude>commons-logging:*</exclude>
                         <!-- log4j is forbidden and must be replaced by org.slf4j:log4j-over-slf4j -->
                         <exclude>log4j:*</exclude>
                         <exclude>org.apache.logging.log4j:*</exclude>
@@ -413,12 +409,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                         <exclude>*:xmlParserAPIs:*</exclude>
                         <!-- PLF-6122: Exclude icepdf older than 5.1.0. The groupId for Open Source bundles is now org.icepdf.os -->
                         <exclude>org.icepdf:icepdf-core:*</exclude>
-                        <!-- DEP-101: Elasticsearch depends on lucene version incompatible with the JCR -->
-                        <exclude>org.apache.lucene:*:4</exclude>
                       </excludes>
                       <includes>
-                        <!-- This artifact isn't by default in tomcat -->
-                        <include>org.apache.tomcat:tomcat-catalina-jmx-remote</include>
                         <!-- We can use the tomcat distro -->
                         <include>org.apache.tomcat:tomcat:zip</include>
                         <!--only 1.0 of badArtifact is allowed-->

--- a/services/plf-tomcat-pc-creator-listener/pom.xml
+++ b/services/plf-tomcat-pc-creator-listener/pom.xml
@@ -45,7 +45,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </exclusion>
         <exclusion>
           <groupId>io.swagger.core.v3</groupId>
-          <artifactId>swagger-annotations</artifactId>
+          <artifactId>swagger-annotations-jakarta</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Exclude useless third party libraries and adjust logging level with some default settings for liquibase to not make it verbose.
( Resolves Meeds-io/MIPs#57 )