### PR TITLE
fix: Allow to use Log4J Over SLF4J artifact for apache POI - MEED-3174 - Meeds-io/meeds#1540 (#1541)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,11 +359,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                         <!-- Ant and related aren't really useful for us at runtime -->
                         <exclude>org.apache.ant:*</exclude>
                         <exclude>org.apache.axis:axis-ant:*</exclude>
-                        <!-- commons-logging is forbidden and must be replaced by org.slf4j:jcl-over-slf4j -->
-                        <exclude>commons-logging:*</exclude>
-                        <!-- log4j is forbidden and must be replaced by org.slf4j:log4j-over-slf4j -->
+                        <!-- log4j is forbidden and must be replaced by org.apache.logging.log4j:log4j-to-slf4j -->
                         <exclude>log4j:*</exclude>
-                        <exclude>org.apache.logging.log4j:*</exclude>
+                        <exclude>org.apache.logging.log4j:log4j-core</exclude>
                         <!-- We use jcl-over-slf4j, thus this one is forbidden to avoid infinite loops -->
                         <exclude>org.slf4j:slf4j-jcl:*</exclude>
                         <!-- We use log4j-over-slf4j, thus this one is forbidden to avoid infinite loops -->


### PR DESCRIPTION
Prior to this change, no Log4J artifact was accepted in Meeds Package. Apache POI is used by gamification to export achievements which depends on Log4J API. This change will allow to introduce Log4J API with log4j-to-slf4j artifact in order to bridge Log4J logging to be made using logback instead.

( Resolves Meeds-io/meeds#1540 )

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - Meeds-io/MIPs#1234
or
fix: Fix TITLE - MEED-XXXX - Meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
