### PR TITLE
feat: hide the shared layout from the content editor page - EXO-72846 - Meeds-io/MIPs#128

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -362,6 +362,53 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>ContentEditorPageLayoutUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>150</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>overview.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>newsComposer</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -3038,6 +3038,8 @@
     <title>News Composer</title>
     <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
     <edit-permission>*:/platform/administrators</edit-permission>
+    <show-max-window>true</show-max-window>
+    <hide-shared-layout>true</hide-shared-layout>
     <container id="NewsDetailContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
       <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
       <portlet-application>


### PR DESCRIPTION
Prior to this change, the shared layout was present on the content editor page, and the editor did not take the maximum width of the window, which hid the right editor actions. This change will set the two  properties hide-shared-layout and show-max-window to true and configure an upgrade plugin to update the content editor page, resolving these issues.