### PR TITLE
Fix io.meeds.distribution property version affectation

### DIFF
--- a/services/plf-community-edition-service/src/main/resources/conf/platform.properties
+++ b/services/plf-community-edition-service/src/main/resources/conf/platform.properties
@@ -29,4 +29,4 @@ io.meeds.social=@io.meeds.social.version@
 
 # Platform version
 org.exoplatform.platform=@io.meeds.social.version@
-io.meeds=@io.meeds.social.version@
+io.meeds.distribution=@io.meeds.social.version@


### PR DESCRIPTION
Before this fix, when checking /rest/platform/info, the `io.meeds.distribution` property is missing which raises an exception. This change will ensure that the missing property gets the correct platform version

```bash
org.exoplatform.commons.info.MissingProductInformationException: Missing product information property: io.meeds.distribution
	at org.exoplatform.commons.info.ProductInformations.getVersion(ProductInformations.java:163)
	at org.exoplatform.commons.info.ProductInformations.getVersion(ProductInformations.java:154)
	at org.exoplatform.commons.info.PlatformInformationRESTService.getPlatformInformation(PlatformInformationRESTService.java:76)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```