### PR TITLE
fix: Add Workaround for Apache Tomcat Manifest rule enforcer violation - MEED-7171 - Meeds-io/meeds#2249

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -476,6 +476,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     <!-- This rule checks the dependencies transitively and fails if any class of any dependency is having its bytecode version higher than the one specified. -->
                     <enforceBytecodeVersion>
                       <maxJdkVersion>${maven.compiler.target}</maxJdkVersion>
+                      <!--
+                        Excluded some Apache Tomcat artifacts since it "advertises Java 22" while the compatibility on 10.1 is Java 17+ 
+                        FIXME: TO DELETE Once Java 22 is support by Meeds (Next upgrade for next JDK LTS version)
+                      -->
+                      <excludes>
+                        <exclude>org.apache.tomcat.embed:tomcat-embed-core</exclude>
+                        <exclude>org.apache.tomcat:tomcat-coyote</exclude>
+                      </excludes>
                     </enforceBytecodeVersion>
                   </rules>
                   <fail>true</fail>


### PR DESCRIPTION
Prior to this change, when building the project using Apache Tomcat version 10.1.25 (upgraded from 10.1.17), the '`enforceBytecodeVersion`' enforcer rule failed due to a change in Manifest of Apache Tomcat which want to '`advertises Java 22`'. Knowing that the Apache Tomcat 10.1 is still compatible with `Java 17+`, this change will just ignore impacted jars to overpass the failure.