### PR TITLE
feat: Move applications menu to third place in administration site - MEED-7431 - Meeds-io/meeds#2365

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/navigation.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/navigation.xml
@@ -76,6 +76,34 @@
         </node>
       </node>
       <node>
+        <name>applications</name>
+        <label>#{portal.administration.applications}</label>
+        <icon>fas fa-boxes</icon>
+        <node>
+          <name>applicationsCenter</name>
+          <label>#{portal.administration.appCenterAdminSetup}</label>
+          <icon>fas fa-list-alt</icon>
+          <page-reference>portal::administration::appCenterAdminSetup</page-reference>
+        </node>
+        <node>
+          <name>pwaSettings</name>
+          <label>#{portal.administration.pwaSettings}</label>
+          <icon>fas fa-mobile-alt</icon>
+          <page-reference>portal::administration::pwaSettings</page-reference>
+        </node>
+        <node>
+          <name>news-settings</name>
+          <label>#{portal.administration.news-settings}</label>
+          <icon>fas fa-newspaper</icon>
+          <node>
+            <name>newsTargets</name>
+            <label>#{portal.administration.newsTargets}</label>
+            <icon>fas fa-bullseye</icon>
+            <page-reference>portal::administration::newsTargets</page-reference>
+          </node>
+        </node>
+      </node>
+      <node>
         <name>recognition</name>
         <label>#{portal.administration.recognition}</label>
         <icon>fas fa-trophy</icon>
@@ -108,34 +136,6 @@
           <label>#{portal.administration.badges}</label>
           <icon>fas fa-graduation-cap</icon>
           <page-reference>portal::administration::gamificationBadgesAdministration</page-reference>
-        </node>
-      </node>
-      <node>
-        <name>applications</name>
-        <label>#{portal.administration.applications}</label>
-        <icon>fas fa-boxes</icon>
-        <node>
-          <name>applicationsCenter</name>
-          <label>#{portal.administration.appCenterAdminSetup}</label>
-          <icon>fas fa-list-alt</icon>
-          <page-reference>portal::administration::appCenterAdminSetup</page-reference>
-        </node>
-        <node>
-          <name>pwaSettings</name>
-          <label>#{portal.administration.pwaSettings}</label>
-          <icon>fas fa-mobile-alt</icon>
-          <page-reference>portal::administration::pwaSettings</page-reference>
-        </node>
-        <node>
-          <name>news-settings</name>
-          <label>#{portal.administration.news-settings}</label>
-          <icon>fas fa-newspaper</icon>
-          <node>
-            <name>newsTargets</name>
-            <label>#{portal.administration.newsTargets}</label>
-            <icon>fas fa-bullseye</icon>
-            <page-reference>portal::administration::newsTargets</page-reference>
-          </node>
         </node>
       </node>
       <node>


### PR DESCRIPTION
This change will move applications menu to third place in administration site. This change isn't applied to existing platforms,only for new installations without data or if a `merge`/`overwrite` `importMode` is used.