### PR TITLE
feat: Change Space Home Image Portlet - MEED-7442 - Meeds-io/MIPs#7442 - Meeds-io/MIPs#147

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/template/pages/spaceHomePage/page.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/template/pages/spaceHomePage/page.xml
@@ -30,9 +30,12 @@
         <portlet-application>
           <portlet>
             <application-ref>social-portlet</application-ref>
-            <portlet-ref>SpaceBannerPortlet</portlet-ref>
+            <portlet-ref>Image</portlet-ref>
           </portlet>
-          <title>Space Banner</title>
+          <title>Image</title>
+          <css-style>
+            <mobile-hidden>true</mobile-hidden>
+          </css-style>
         </portlet-application>
       </column>
     </section-columns>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -594,6 +594,45 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin profiles="layout">
+      <name>SpaceBannerRemovalPortletsUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.layout.plugin.upgrade.LayoutApplicationReferenceUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>5</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute only once, not each version change</description>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>SpaceBannerPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>remove</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceBannerPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>false</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 


### PR DESCRIPTION
This change will change the Space Banner portlet to use the Space Image portlet instead. In addition, this will add an upgrade plugin to delete the space Banner Portlet from portlet instances.