### PR TITLE
feat: Configure Space Settings Page in Crowdfunding Space Template - MEED-7457 - Meeds-io/meeds#2377

### DIFF
--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/space-template-configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/space-template-configuration.xml
@@ -67,6 +67,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     <field name="icon">
                       <string>fas fa-wallet</string>
                     </field>
+                    <field name="profiles">
+                      <string>wallet</string>
+                    </field>
                   </object>
                 </value>
               </collection>

--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/social-extension/social/spaces-templates-configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/social-extension/social/spaces-templates-configuration.xml
@@ -124,6 +124,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     <field name="icon">
                       <string>fas fa-tasks</string>
                     </field>
+                    <field name="profiles">
+                      <string>task</string>
+                    </field>
                   </object>
                 </value>
                 <value>
@@ -149,6 +152,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     <field name="icon">
                       <string>fas fa-clipboard</string>
                     </field>
+                    <field name="profiles">
+                      <string>notes</string>
+                    </field>
                   </object>
                 </value>
                 <value>
@@ -173,6 +179,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     </field>
                     <field name="icon">
                       <string>fas fa-cog</string>
+                    </field>
+                    <field name="roles">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>manager</string>
+                        </value>
+                      </collection>
                     </field>
                   </object>
                 </value>


### PR DESCRIPTION
This change will allow to configure profiles on pages of Crowdfunding based spaces so that when an addon is uninstalled, the page isn't displayed anymore. In addition, this change will add the default roles of type 'manager' on 'settings' page.