### PR TITLE
feat: Add I18N keys for Sites Name and Description in configuration - MEED-3342 - Meeds-io/meeds#1629

### DIFF
--- a/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/administration_en.properties
+++ b/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/administration_en.properties
@@ -14,6 +14,8 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+portal.administration.name=Platform settings
+portal.administration.description=A site for administration features
 portal.administration.home=Platform settings
 portal.administration.general=General
 portal.administration.organisation=Organization

--- a/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/contribute_en.properties
+++ b/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/contribute_en.properties
@@ -17,6 +17,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+portal.contribute.name=Contribute
+portal.contribute.description=Easily onboard contributors, drive initiatives, and keep everyone motivated
 portal.contribute.overview=Overview
 portal.contribute.actions=Actions
 portal.contribute.programs=Programs

--- a/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/global_en.properties
@@ -16,6 +16,8 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+portal.global.name=Global
+portal.global.description=A site for system pages
 portal.global.searchResult=Search Result
 portal.global.stream=Stream
 portal.global.spaces=Spaces

--- a/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/mycraft_en.properties
+++ b/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/mycraft_en.properties
@@ -17,6 +17,8 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+portal.mycraft.name=My Workspace
+portal.mycraft.description=Access your workspace directly, organized by topic
 portal.mycraft.dashboard=Dashboard
 portal.mycraft.stream=Stream
 portal.mycraft.myWorspace=My Workspace

--- a/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/public_en.properties
+++ b/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/public_en.properties
@@ -16,5 +16,7 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+portal.public.name=Public site
+portal.public.description=Public site accessible for anonymous users
 portal.public.overview=Overview
 portal.public.actions=Actions

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
@@ -24,7 +24,8 @@
         xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_10 http://www.gatein.org/xml/ns/gatein_objects_1_10"
         xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_10">
   <portal-name>administration</portal-name>
-  <label>Platform settings</label>
+  <label>#{portal.administration.name}</label>
+  <description>#{portal.administration.description}</description>
   <displayed>false</displayed>
   <locale>en</locale>
   <access-permissions>*:/platform/users</access-permissions>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/contribute/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/contribute/portal.xml
@@ -25,8 +25,8 @@
   xmlns="http://www.exoplatform.org/xml/ns/gatein_objects_1_11">
 
   <portal-name>contribute</portal-name>
-  <label>Contribute</label>
-  <description>Easily onboard contributors, drive initiatives, and keep everyone motivated</description>
+  <label>#{portal.contribute.name}</label>
+  <description>#{portal.contribute.description}</description>
   <display-order>10</display-order>
   <locale>en</locale>
   <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/portal.xml
@@ -20,6 +20,8 @@
 -->
 <portal-config>
     <portal-name>global</portal-name>
+    <label>#{portal.global.name}</label>
+    <description>#{portal.global.description}</description>
     <locale>en</locale>
     <access-permissions>Everyone</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/mycraft/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/mycraft/portal.xml
@@ -25,8 +25,8 @@
   xmlns="http://www.exoplatform.org/xml/ns/gatein_objects_1_11">
 
   <portal-name>mycraft</portal-name>
-  <label>My Workspace</label>
-  <description>Access your workspace directly, organized by topic</description>
+  <label>#{portal.mycraft.name}</label>
+  <description>#{portal.mycraft.description}</description>
   <display-order>20</display-order>
   <locale>en</locale>
   <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/portal.xml
@@ -24,6 +24,8 @@
   xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_10 http://www.gatein.org/xml/ns/gatein_objects_1_10"
   xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_10">
   <portal-name>public</portal-name>
+  <label>#{portal.public.name}</label>
+  <description>#{portal.public.description}</description>
   <displayed>false</displayed>
   <locale>en</locale>
   <access-permissions>*:/platform/administrators;publisher:/platform/web-contributors</access-permissions>


### PR DESCRIPTION
After the enhanced behavior made on Meeds-io/gatein-portal#969 , Meeds-io/social#4028 and Meeds-io/layout#217, this change will provide the default sites keys to be translated using crowdin synchronization mechanism.