### PR TITLE
fix: Fix Reference to PageNotFound in navigation - MEED-7500 - Meeds-io/meeds#2390

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -422,6 +422,49 @@
       </init-params>
     </component-plugin>
     <component-plugin>
+      <name>GlobalSiteNavigationUpdate</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>global.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updateNavigation">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="importMode">
+              <string>merge</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
       <name>PwaAdministrationPageLayoutUpgrade</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/navigation.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/navigation.xml
@@ -299,7 +299,7 @@
       <name>page-not-found</name>
       <label>#{portal.global.pageNotFound}</label>
       <visibility>SYSTEM</visibility>
-      <page-reference>portal::global::pageNotFound</page-reference>
+      <page-reference>portal::global::page-not-found</page-reference>
     </node>
     <node>
       <name>news-detail</name>


### PR DESCRIPTION
This change will fix the reference to page name in 'page-not-found' navigation. In addition, this will add an upgrade plugin to reimport pages navigations to update the reference for existing installations.