### PR TITLE
feat: Add space Space Description Portlet in Home Page - MEED-7473 - Meeds-io/MIPs#151

### DIFF
--- a/packaging/plf-packaging-resources/src/main/resources/controller.xml
+++ b/packaging/plf-packaging-resources/src/main/resources/controller.xml
@@ -124,6 +124,15 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </path-param>
   </route>
 
+  <route path="/s/{spaceId}/{path}">
+    <route-param qname="gtn:handler">
+      <value>spaces</value>
+    </route-param>
+    <path-param qname="path" encoding="preserve-path">
+      <pattern>.*</pattern>
+    </path-param>
+  </route>
+
   <!-- SEO route -->
   <route path="/{gtn:sitename}/sitemaps.xml">
     <route-param qname="gtn:handler">

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/template/pages/spaceHomePage/page.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/template/pages/spaceHomePage/page.xml
@@ -55,9 +55,9 @@
         <portlet-application>
           <portlet>
             <application-ref>social-portlet</application-ref>
-            <portlet-ref>SpaceInfos</portlet-ref>
+            <portlet-ref>SpaceDescription</portlet-ref>
           </portlet>
-          <title>Space Infos</title>
+          <title>Space Description</title>
         </portlet-application>
         <portlet-application>
           <portlet>


### PR DESCRIPTION
This change will delete the Space info portlet and replace it from Home, in order to replace it by the Space description portlet. In addition, this change will introduce the Spaces Handler which will give the possibility to have a direct access to a space switch its id instead of pretty name.