### PR TITLE
fix: Fix Logback Configuration upgraded to 1.5 - MEED-7622 - Meeds-io/meeds#2475

### DIFF
--- a/packaging/plf-tomcat-resources/src/main/resources/conf/logback.xml
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/logback.xml
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 Logback ${ch.qas.logback.version} configuration file.
 For more details see : http://logback.qos.ch/manual/configuration.html
 -->
-<configuration scan="${EXO_DEV}" scanPeriod="30 seconds" debug="false">
+<configuration scan="${EXO_DEV}" scanPeriod="30 seconds" debug="${EXO_DEV}">
   <!-- Default pattern used for printing logs in files and on the console for systems that doesn't support a colorized output -->
   <property name="exo.logs.default.pattern" value="%date{ISO8601} | %-5level | %msg [%logger{40}&lt;%thread&gt;] %n%xEx" />
   <!-- Pattern used for console supporting ANSI colors -->
@@ -60,7 +60,7 @@ For more details see : http://logback.qos.ch/manual/configuration.html
       <fileNamePattern>${catalina.base}/logs/platform-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
       <!-- Max number of archives to keep -->
       <maxHistory>${exo.logs.rolling.maxHistory}</maxHistory>
-      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy">
         <!-- or whenever the file size reaches maxFileSize -->
         <maxFileSize>${exo.logs.rolling.maxFileSize}</maxFileSize>
       </timeBasedFileNamingAndTriggeringPolicy>
@@ -141,7 +141,7 @@ For more details see : http://logback.qos.ch/manual/configuration.html
           <fileNamePattern>${catalina.base}/logs/leak-detector-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
           <!-- Max number of archives to keep -->
           <maxHistory>${exo.logs.rolling.maxHistory}</maxHistory>
-          <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+          <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy">
             <!-- or whenever the file size reaches maxFileSize -->
             <maxFileSize>${exo.logs.rolling.maxFileSize}</maxFileSize>
           </timeBasedFileNamingAndTriggeringPolicy>

--- a/packaging/plf-tomcat-resources/src/main/resources/conf/server.template.xml
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/server.template.xml
@@ -108,7 +108,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                connectionTimeout="20000" disableUploadTimeout="true"
                URIEncoding="UTF-8"
                compression="off" compressionMinSize="2048"
-               noCompressionUserAgents=".*MSIE 6.*" compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript">
+               noCompressionUserAgents=".*MSIE 6.*" compressibleMimeType="text/html,text/xml,text/plain,text/css,text/javascript">
       <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
     </Connector>
 


### PR DESCRIPTION
Prior to this change, the `logback` configuration fails to parse silently due to a changed FQN from version **1.4 to 1.5**. This change will:
- Ensure that the file parsing fail is logged when using **Dev Mode** to not swallow and **hide errors**
- Change the FQN of '`timeBasedFileNamingAndTriggeringPolicy`' to the newly introduced FQN '`ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy`' Update renamed Tomcat property name `compressableMimeType` to `compressibleMimeType`.

Resolves https://github.com/Meeds-io/meeds/issues/2475