### PR TITLE
feat: Combine Social Web Archives to one single social.war - Meeds-io/MIPs#150

### DIFF
--- a/packaging/plf-dependencies/pom.xml
+++ b/packaging/plf-dependencies/pom.xml
@@ -94,19 +94,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- Social -->
     <dependency>
       <groupId>io.meeds.social</groupId>
-      <artifactId>social-webapp-portlet</artifactId>
+      <artifactId>social-webapp</artifactId>
       <type>war</type>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>io.meeds.social</groupId>
-      <artifactId>social-extension-war</artifactId>
-      <type>war</type>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.meeds.social</groupId>
-      <artifactId>social-extension-war</artifactId>
+      <artifactId>social-webapp</artifactId>
       <type>pom</type>
       <scope>import</scope>
       <exclusions>

--- a/services/plf-configuration/src/main/resources/conf/platform/configuration.xml
+++ b/services/plf-configuration/src/main/resources/conf/platform/configuration.xml
@@ -77,10 +77,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                   <string>cometd</string>
                </value>
                <value>
-                  <string>social-extension</string>
-               </value>
-               <value>
-                  <string>social-portlet</string>
+                  <string>social</string>
                </value>
             </collection>
           </field>

--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/social-extension/social/spaces-templates-configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/social-extension/social/spaces-templates-configuration.xml
@@ -61,7 +61,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <field name="homePageApplication">
               <object type="org.exoplatform.social.core.space.SpaceApplication">
                 <field name="portletApp">
-                  <string>social-portlet</string>
+                  <string>social</string>
                 </field>
                 <field name="portletName">
                   <string>SpaceActivityStreamPortlet</string>
@@ -79,7 +79,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 <value>
                   <object type="org.exoplatform.social.core.space.SpaceApplication">
                     <field name="portletApp">
-                      <string>social-portlet</string>
+                      <string>social</string>
                     </field>
                     <field name="portletName">
                       <string>MembersPortlet</string>
@@ -160,7 +160,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 <value>
                   <object type="org.exoplatform.social.core.space.SpaceApplication">
                     <field name="portletApp">
-                      <string>social-portlet</string>
+                      <string>social</string>
                     </field>
                     <field name="portletName">
                       <string>SpaceSettingPortlet</string>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/template/navigationWebsite/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/template/navigationWebsite/pages.xml
@@ -33,7 +33,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>Image</portlet-ref>
             </portlet>
           </portlet-application>
@@ -51,7 +51,7 @@
         <column col-span="4">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>Links</portlet-ref>
             </portlet>
           </portlet-application>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/template/navigationWebsite/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/template/navigationWebsite/portal.xml
@@ -38,7 +38,7 @@
           <access-permissions>Everyone</access-permissions>
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>VerticalMenu</portlet-ref>
             </portlet>
             <title>Site Vertical Menu</title>
@@ -54,7 +54,7 @@
             <access-permissions>Everyone</access-permissions>
             <portlet-application>
               <portlet>
-                <application-ref>social-portlet</application-ref>
+                <application-ref>social</application-ref>
                 <portlet-ref>Breadcrumb</portlet-ref>
               </portlet>
               <title>Site Breadcrumb application</title>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/template/spacePublic/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/template/spacePublic/pages.xml
@@ -33,7 +33,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>SpaceBannerPortlet</portlet-ref>
             </portlet>
           </portlet-application>
@@ -43,7 +43,7 @@
         <column col-span="8">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>SpaceWidgetDescription</portlet-ref>
             </portlet>
           </portlet-application>
@@ -51,13 +51,13 @@
         <column col-span="4">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>SpaceWidgetManagers</portlet-ref>
             </portlet>
           </portlet-application>
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>SpaceWidgetMembers</portlet-ref>
             </portlet>
           </portlet-application>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/template/spacePublic/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/template/spacePublic/portal.xml
@@ -33,7 +33,7 @@
         <access-permissions>Everyone</access-permissions>
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>TopBarLogo</portlet-ref>
           </portlet>
           <title>Space Logo</title>
@@ -61,7 +61,7 @@
         <access-permissions>Everyone</access-permissions>
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>TopBarLogin</portlet-ref>
           </portlet>
           <title>Login Button</title>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/template/pages/spaceHomePage/page.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/template/pages/spaceHomePage/page.xml
@@ -29,7 +29,7 @@
       <column col-span="12">
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>Image</portlet-ref>
           </portlet>
           <title>Image</title>
@@ -45,7 +45,7 @@
       <column col-span="8">
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>SpaceActivityStreamPortlet</portlet-ref>
           </portlet>
           <title>Space Activity Stream</title>
@@ -54,28 +54,28 @@
       <column col-span="4">
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>SpaceWidgetDescription</portlet-ref>
           </portlet>
           <title>Space Description</title>
         </portlet-application>
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>SpaceWidgetManagers</portlet-ref>
           </portlet>
           <title>Space Managers</title>
         </portlet-application>
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>SpaceWidgetMembers</portlet-ref>
           </portlet>
           <title>Space Members</title>
         </portlet-application>
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>WhoIsOnLinePortlet</portlet-ref>
           </portlet>
           <title>Who is on Line</title>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -672,13 +672,24 @@
           <value>true</value>
         </value-param>
         <object-param>
-          <name>ExternalSpacesList</name>
+          <name>SocialPortletExternalSpacesList</name>
           <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
             <field name="modificationType">
               <string>remove</string>
             </field>
             <field name="oldContentId">
               <string>social-portlet/ExternalSpacesList</string>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SocialExternalSpacesList</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>remove</string>
+            </field>
+            <field name="oldContentId">
+              <string>social/ExternalSpacesList</string>
             </field>
           </object>
         </object-param>
@@ -745,7 +756,24 @@
           <value>true</value>
         </value-param>
         <object-param>
-          <name>SpaceInfos</name>
+          <name>SocialSpaceInfos</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>remove</string>
+            </field>
+            <field name="oldContentId">
+              <string>social/SpaceInfos</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>false</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SocialPortletSpaceInfos</name>
           <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
             <field name="modificationType">
               <string>remove</string>
@@ -784,7 +812,7 @@
           <value>true</value>
         </value-param>
         <object-param>
-          <name>SpacesOverview</name>
+          <name>SocialPortletSpacesOverview</name>
           <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
             <field name="modificationType">
               <string>remove</string>
@@ -794,6 +822,1085 @@
             </field>
             <field name="upgradePages">
               <boolean>false</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SocialSpacesOverview</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>remove</string>
+            </field>
+            <field name="oldContentId">
+              <string>social/SpacesOverview</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>false</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin profiles="layout">
+      <name>SocialPortletToSocialUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.layout.plugin.upgrade.LayoutApplicationReferenceUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>500</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute only once, not each version change</description>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>SpaceAccessPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceAccessPortlet</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>PageNotFound</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/PageNotFound</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>IDMUsersManagement</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/IDMUsersManagement</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>IDMGroupsManagement</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/IDMGroupsManagement</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>IDMMembershipTypesManagement</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/IDMMembershipTypesManagement</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>WhoIsOnLinePortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/WhoIsOnLinePortlet</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpaceInfos</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceInfos</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpaceWidgetDescription</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceWidgetDescription</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpaceWidgetManagers</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceWidgetManagers</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpaceWidgetMembers</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceWidgetMembers</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>MembersPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/MembersPortlet</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpaceTopbarMenu</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceTopbarMenu</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpaceMenuPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceMenuPortlet</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpaceBannerPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceBannerPortlet</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpaceActivityStreamPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceActivityStreamPortlet</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>UserActivityStreamPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/UserActivityStreamPortlet</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>UserSettingLanguage</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/UserSettingLanguage</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>UserSettingNotifications</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/UserSettingNotifications</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>UserSettingSecurity</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/UserSettingSecurity</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>HamburgerMenu</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/HamburgerMenu</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpaceSettingPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceSettingPortlet</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpacesAdministration</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpacesAdministration</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>TopBarLogo</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/TopBarLogo</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>TopBarPreview</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/TopBarPreview</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>TopBarLogin</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/TopBarLogin</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>TopBarPublishSite</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/TopBarPublishSite</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>ProfileHeader</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/ProfileHeader</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>ProfileContactInformation</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/ProfileContactInformation</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>ProfileWorkExperience</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/ProfileWorkExperience</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>ProfileAboutMe</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/ProfileAboutMe</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>TopBarNotification</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/TopBarNotification</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>TopBarFavorites</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/TopBarFavorites</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>GettingStarted</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/GettingStarted</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>ExternalSpacesList</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/ExternalSpacesList</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpacesList</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpacesList</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SpacesOverview</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpacesOverview</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>PeopleList</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/PeopleList</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>PeopleOverview</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/PeopleOverview</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>SuggestionsPeopleAndSpace</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SuggestionsPeopleAndSpace</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>Search</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/Search</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>GeneralSettings</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/GeneralSettings</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>Popover</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/Popover</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>TopBarMenu</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/TopBarMenu</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>ProfileSettingsPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/ProfileSettingsPortlet</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>Image</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/Image</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>Links</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/Links</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>DrawersOverlay</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/DrawersOverlay</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>NotificationAdministration</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/NotificationAdministration</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>VerticalMenu</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/VerticalMenu</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>Breadcrumb</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/Breadcrumb</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>PlatformSettings</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/PlatformSettings</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+        <object-param>
+          <name>OrganizationalChart</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>update</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/OrganizationalChart</string>
+            </field>
+            <field name="newContentId">
+              <string>social/SpaceAccessPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
             </field>
             <field name="upgradePortletInstance">
               <boolean>true</boolean>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/pages.xml
@@ -33,7 +33,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
                 <portlet-ref>GeneralSettings</portlet-ref>
             </portlet>
             <title>General Settings Portlet</title>
@@ -53,7 +53,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>NotificationAdministration</portlet-ref>
             </portlet>
             <title>Notifications Administration</title>
@@ -100,7 +100,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>IDMUsersManagement</portlet-ref>
             </portlet>
             <title>Users Management</title>
@@ -120,7 +120,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>IDMGroupsManagement</portlet-ref>
             </portlet>
             <title>Groups Management</title>
@@ -140,7 +140,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>ProfileSettingsPortlet</portlet-ref>
             </portlet>
             <title>Profile Settings Management</title>
@@ -161,7 +161,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>SpacesAdministration</portlet-ref>
             </portlet>
           </portlet-application>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
@@ -42,7 +42,7 @@
           <access-permissions>*:/platform/users</access-permissions>
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>VerticalMenu</portlet-ref>
             </portlet>
             <title>Site Vertical Menu</title>
@@ -58,7 +58,7 @@
             <access-permissions>*:/platform/users</access-permissions>
             <portlet-application>
               <portlet>
-                <application-ref>social-portlet</application-ref>
+                <application-ref>social</application-ref>
                 <portlet-ref>Breadcrumb</portlet-ref>
                 <preferences>
                   <preference>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/contribute/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/contribute/pages.xml
@@ -34,7 +34,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>Image</portlet-ref>
               <preferences>
                 <preference>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -37,7 +37,7 @@
         <column col-span="8">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>PeopleList</portlet-ref>
             </portlet>
             <title>All People</title>
@@ -46,14 +46,14 @@
         <column col-span="4">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>PeopleOverview</portlet-ref>
             </portlet>
             <title>People Overview Portlet</title>
           </portlet-application>
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>SuggestionsPeopleAndSpace</portlet-ref>
               <preferences>
                 <preference>
@@ -85,7 +85,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>SpacesList</portlet-ref>
             </portlet>
             <title>All Spaces</title>
@@ -105,7 +105,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>UserActivityStreamPortlet</portlet-ref>
             </portlet>
             <title>User Activity Stream</title>
@@ -132,7 +132,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>SpaceAccessPortlet</portlet-ref>
             </portlet>
             <title>space-access</title>
@@ -152,7 +152,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>PageNotFound</portlet-ref>
             </portlet>
             <title>Page Not Found</title>
@@ -172,21 +172,21 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>UserSettingLanguage</portlet-ref>
             </portlet>
             <title>User Setting Language</title>
           </portlet-application>
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>UserSettingNotifications</portlet-ref>
             </portlet>
             <title>User Setting Notifications</title>
           </portlet-application>
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>UserSettingSecurity</portlet-ref>
             </portlet>
             <title>User Setting Security</title>
@@ -210,7 +210,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>ProfileHeader</portlet-ref>
             </portlet>
             <title>Profile Header Portlet</title>
@@ -227,7 +227,7 @@
           </container>
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>ProfileAboutMe</portlet-ref>
             </portlet>
             <title>Profile AboutMe Portlet</title>
@@ -242,7 +242,7 @@
           </container>
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>ProfileContactInformation</portlet-ref>
             </portlet>
             <title>Profile contact information Portlet</title>
@@ -257,7 +257,7 @@
           </container>
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>ProfileWorkExperience</portlet-ref>
             </portlet>
             <title>Profile Work Experience Portlet</title>
@@ -1633,7 +1633,7 @@
         template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>DrawersOverlay</portlet-ref>
           </portlet>
           <title>Drawers Overlay</title>
@@ -1684,7 +1684,7 @@
         template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>DrawersOverlay</portlet-ref>
           </portlet>
           <title>Drawers Overlay</title>
@@ -1751,7 +1751,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>OrganizationalChart</portlet-ref>
               <preferences>
                 <!-- Indicates that the chart setting center user can be modified by admins or not -->

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/mycraft/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/mycraft/pages.xml
@@ -37,7 +37,7 @@
         <column col-span="8">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>UserActivityStreamPortlet</portlet-ref>
             </portlet>
             <title>User Activity Stream</title>
@@ -46,7 +46,7 @@
         <column col-span="4">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>WhoIsOnLinePortlet</portlet-ref>
             </portlet>
             <title>Who is on line</title>
@@ -134,7 +134,7 @@
       <access-permissions>Everyone</access-permissions>
       <portlet-application>
         <portlet>
-          <application-ref>social-portlet</application-ref>
+          <application-ref>social</application-ref>
           <portlet-ref>OrganizationalChart</portlet-ref>
           <preferences>
             <!-- chart center user value can take '@connected@' which refers to the connected user

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/pages.xml
@@ -55,7 +55,7 @@
         <column col-span="12">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>Image</portlet-ref>
               <preferences>
                 <preference>
@@ -100,7 +100,7 @@
         <column col-span="4">
           <portlet-application>
             <portlet>
-              <application-ref>social-portlet</application-ref>
+              <application-ref>social</application-ref>
               <portlet-ref>Links</portlet-ref>
               <preferences>
                 <preference>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/portal.xml
@@ -41,7 +41,7 @@
         <access-permissions>Everyone</access-permissions>
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>TopBarLogo</portlet-ref>
           </portlet>
           <title>Company Logo</title>
@@ -64,7 +64,7 @@
         <access-permissions>*:/platform/administrators;publisher:/platform/web-contributors</access-permissions>
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>TopBarPreview</portlet-ref>
           </portlet>
           <title>Preview Site Button</title>
@@ -77,7 +77,7 @@
         <access-permissions>*:/platform/administrators</access-permissions>
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>TopBarPublishSite</portlet-ref>
           </portlet>
           <title>Publish Site Button</title>
@@ -95,7 +95,7 @@
         <access-permissions>Everyone</access-permissions>
         <portlet-application>
           <portlet>
-            <application-ref>social-portlet</application-ref>
+            <application-ref>social</application-ref>
             <portlet-ref>TopBarLogin</portlet-ref>
           </portlet>
           <title>Login Button</title>


### PR DESCRIPTION
This change will Modify the pages definition to use 'social' instead of 'social-portlet' to reference the Social Module portlets. See https://github.com/Meeds-io/social/pull/4114/commits/9e0766a1069cd23d6af7f094637ab17a4344dc70 for more information about this change.
A dedicated configuration to upgrade the existing pages has been added to upgrade the existing pages to reference the new Webapp Module instead of deleted 'social-portlet' module.