### PR TITLE
feat: Give access to layout editor page to everyone - MEED-7657 - Meeds-io/meeds#2502

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -263,7 +263,7 @@
       </init-params>
     </component-plugin>
     <component-plugin>
-      <name>LayoutEditorPageUpgrade</name>
+      <name>LayoutEditorPagePermissionUpgrade</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
       <init-params>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -1609,7 +1609,7 @@
   <page profiles="layout">
     <name>layout-editor</name>
     <title>Layout Editor</title>
-    <access-permissions>*:/platform/users</access-permissions>
+    <access-permissions>Everyone</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>
     <show-max-window>true</show-max-window>
     <hide-shared-layout>true</hide-shared-layout>


### PR DESCRIPTION
Prior to this change, when adding a page template, the images attached to it are not viewable by External users. This is due to the fact that the access permission of attached image is computed switch page being edited, or if of type page template to current page (layout-editor). This change will fix two bugs:
- Give access to layout-editor page to anyone to let the ACL made by page permissions instead (by the Space Layout permissions if the page is added in a space)
- Make the attached image to a fictive page (not really instanciated yet), accessible to all users since the page can be used in any site/space.
