### PR TITLE
feat: Allow to access Site template through a dedicated Web Handler - MEED-7669 - Meeds-io/MIPs#165

### DIFF
--- a/packaging/plf-packaging-resources/src/main/resources/controller.xml
+++ b/packaging/plf-packaging-resources/src/main/resources/controller.xml
@@ -241,6 +241,19 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </path-param>
   </route>
 
+  <!-- The site template handler -->
+  <route path="/t/{gtn:siteid}/{gtn:path}">
+    <route-param qname="gtn:handler">
+      <value>portal-template</value>
+    </route-param>
+    <request-param qname="gtn:lang" name="lang" value-mapping="never-empty">
+      <pattern>(ar|ar-AE|ar-BH|ar-DZ|ar-EG|ar-IQ|ar-JO|ar-KW|ar-LB|ar-LY|ar-MA|ar-OM|ar-QA|ar-SA|ar-SD|ar-SY|ar-TN|ar-YE|be|be-BY|bg|bg-BG|ca|ca-ES|cs|cs-CZ|da|da-DK|de|de-AT|de-CH|de-DE|de-GR|de-LU|el|el-CY|el-GR|en|en-AU|en-CA|en-GB|en-IE|en-IN|en-MT|en-NZ|en-PH|en-SG|en-US|en-ZA|es|es-AR|es-BO|es-CL|es-CO|es-CR|es-CU|es-DO|es-EC|es-ES|es-GT|es-HN|es-MX|es-NI|es-PA|es-PE|es-PR|es-PY|es-SV|es-US|es-UY|es-VE|et|et-EE|fa|fi|fi-FI|fil|fr|fr-BE|fr-CA|fr-CH|fr-FR|fr-LU|ga|ga-IE|hi|hi-IN|hr|hr-HR|hu|hu-HU|in|in-ID|is|is-IS|it|it-CH|it-IT|iw|iw-IL|ja|ja-JP|ja-JP-JP-#u-ca-japanese|ko|ko-KR|lt|lt-LT|lv|lv-LV|mk|mk-MK|ms|ms-MY|mt|mt-MT|nl|nl-BE|nl-NL|no|no-NO|no-NO-NY|pl|pl-PL|pt|pt-BR|pt-PT|ro|ro-RO|ru|ru-RU|sk|sk-SK|sl|sl-SI|sq|sq-AL|sr|sr-BA|sr-BA-#Latn|sr-CS|sr-ME|sr-ME-#Latn|sr-RS|sr-RS-#Latn|sr--#Latn|sv|sv-SE|th|th-TH|th-TH-TH-#u-nu-thai|tr|tr-TR|uk|uk-UA|vi|vi-VN|zh|zh-CN|zh-HK|zh-SG|zh-TW)?</pattern>
+    </request-param>
+    <path-param qname="gtn:path" encoding="preserve-path">
+      <pattern>.*</pattern>
+    </path-param>
+  </route>
+
   <route path="/">
 
     <!-- The portal handler -->


### PR DESCRIPTION
This change will allow to access the group site template through a dedicated URL in order to allow displaying portlets added into it. This is a temporary Handler that will be changed once WebUI is cleaned up to rely on Portlet container directly instead.