### PR TITLE
feat: Move Search Application to left topbar apps container - MEED-7776 - Meeds-io/MIPs#159

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/sharedlayout.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/sharedlayout.xml
@@ -53,11 +53,6 @@
       <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
       <factory-id>addonContainer</factory-id>
     </container>
-    <container id="SearchPortlet" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-      <name>SearchPortlet</name>
-      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
-      <factory-id>addonContainer</factory-id>
-    </container>
     <container id="middle-topNavigation-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
       <name>middle-topNavigation-container</name>
       <factory-id>addonContainer</factory-id>


### PR DESCRIPTION
This change will Move the Search Application definition to make it added in the same addon container as the other Topbar applications in order to allow configure its display order from General Settings UI.