### PR TITLE
feat: Delete Spaces Page from Meeds Site - MEED-7891 - Meeds-io/MIPs#159

### DIFF
--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal/meeds/navigation.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal/meeds/navigation.xml
@@ -30,11 +30,5 @@
       <icon>fas fa-users</icon>
       <page-reference>portal::global::all-people</page-reference>
     </node>
-    <node>
-      <name>spaces</name>
-      <label>#{portal.meeds.spaces}</label>
-      <icon>fas fa-people-arrows</icon>
-      <page-reference>portal::global::all-spaces</page-reference>
-    </node>
   </page-nodes>
 </node-navigation>


### PR DESCRIPTION
As it is now configurable using Sidebar Admin Options UI, the page is no more needed to be listed in the meta site