### PR TITLE
fix: when migrate from 1.5.x to 7.0.x, space banner are not kept - EXO-76489

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -848,6 +848,49 @@
       </init-params>
     </component-plugin>
     <component-plugin profiles="layout">
+      <name>SpaceBannerHomePageUpdateContentId</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.layout.plugin.upgrade.SpaceBannerHomePageUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>499</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.async.execution</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute only once, not each version change</description>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>SpaceMenuPortlet</name>
+          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
+            <field name="modificationType">
+              <string>remove</string>
+            </field>
+            <field name="oldContentId">
+              <string>social-portlet/SpaceMenuPortlet</string>
+            </field>
+            <field name="upgradePages">
+              <boolean>true</boolean>
+            </field>
+            <field name="upgradePortletInstance">
+              <boolean>true</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin profiles="layout">
       <name>SocialPortletToSocialUpgradePlugin</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.layout.plugin.upgrade.LayoutApplicationReferenceUpgradePlugin</type>
@@ -1878,23 +1921,6 @@
             </field>
             <field name="newContentId">
               <string>social/SpaceBannerPortlet</string>
-            </field>
-            <field name="upgradePages">
-              <boolean>true</boolean>
-            </field>
-            <field name="upgradePortletInstance">
-              <boolean>true</boolean>
-            </field>
-          </object>
-        </object-param>
-        <object-param>
-          <name>SpaceMenuPortlet</name>
-          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
-            <field name="modificationType">
-              <string>remove</string>
-            </field>
-            <field name="oldContentId">
-              <string>social-portlet/SpaceMenuPortlet</string>
             </field>
             <field name="upgradePages">
               <boolean>true</boolean>


### PR DESCRIPTION
Before this fix, an UP removes portlet social-portal/SpaceMenuPortlet from all spaces pages Then the banner is also removed from the space home page This commit add an UP which execute BEFORE this plugin. This new UP search for space home pages, and replace portlet SpaceMenuPortlet by SpaceBannerPortlet. Then, the initial UP executes and remove SpaceMenuPortlet for all other pages.

Resovles Meeds-io/meeds#2689

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - Meeds-io/MIPs#1234
or
fix: Fix TITLE - MEED-XXXX - Meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
