### PR TITLE
feat: Move System Addon Containers as UIPortalApplication extensions - MEED-8281 - Meeds-io/MIPs#175

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/sharedlayout.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/portal/sharedlayout.xml
@@ -9,6 +9,7 @@
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
   version 3 of the License, or (at your option) any later version.
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -26,7 +27,10 @@
     id="ParentSiteContainer"
     template="system:/groovy/portal/webui/workspace/UIParentSiteContainer.gtmpl">
 
-  <container id="UITopBarContainer" template="system:/groovy/portal/webui/container/UITopBarContainer.gtmpl">
+  <container
+    id="UITopBarContainer"
+    template="system:/groovy/portal/webui/container/UITopBarContainer.gtmpl"
+    cssClass="layout-banner-top-section layout-sticky-section">
     <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
     <container id="left-topNavigation-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl" attribute="">
       <name>left-topNavigation-container</name>
@@ -44,22 +48,19 @@
       <name>right-topNavigation-container</name>
       <factory-id>addonContainer</factory-id>
     </container>
-    <container id="MiddleToolBar" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-      <name>MiddleToolBar</name>
-      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
-      <factory-id>addonContainer</factory-id>
+    <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
+      <portlet-application>
+        <portlet>
+          <application-ref>social</application-ref>
+          <portlet-ref>TopBarMenu</portlet-ref>
+        </portlet>
+        <title>Top Bar Menu</title>
+      </portlet-application>
     </container>
     <container id="middle-topNavigation-container" template="groovy/social/webui/UITopbarApplicationsContainer.gtmpl">
       <name>middle-topNavigation-container</name>
       <factory-id>addonContainer</factory-id>
     </container>
-    <container id="TopbarLoadingContainer" template="system:/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl">
-      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
-    </container>
   </container>
   <site-body />
-  <container id="bottom-all-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-    <name>bottom-all-container</name>
-    <factory-id>addonContainer</factory-id>
-  </container>
 </container>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/template/pages/grid/page.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/portal/template/pages/grid/page.xml
@@ -43,7 +43,7 @@
           Kept as an example: can be used on one of the following elements only:
           - 'cell'
           - 'portlet-application' when its parent is of type 'column'
-          <style>
+          <css-style>
             <margin-top>20</margin-top>
             <margin-bottom>20</margin-bottom>
             <margin-right>20</margin-right>
@@ -54,7 +54,7 @@
             <radius-bottom-left>8</radius-bottom-left>
             <mobile-hidden>false</mobile-hidden>
             <border-color>#FFFFFF</border-color>
-          </style>
+          </css-style>
        -->
       </cell>
       <!--

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -121,50 +121,6 @@
       </init-params>
     </component-plugin>
     <component-plugin>
-      <name>BreadcrumbAdministrationSiteLayoutUpgrade</name>
-      <set-method>addUpgradePlugin</set-method>
-      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
-      <description>An upgrade plugin to delete some recognition administration navigations</description>
-      <init-params>
-        <value-param>
-          <name>product.group.id</name>
-          <value>org.exoplatform.social</value>
-        </value-param>
-        <value-param>
-          <name>plugin.execution.order</name>
-          <value>120</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.execute.once</name>
-          <value>true</value>
-        </value-param>
-        <value-param>
-          <name>enabled</name>
-          <value>true</value>
-        </value-param>
-        <object-param>
-          <name>overview.upgrade</name>
-          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
-            <field name="updatePortalConfig">
-              <boolean>true</boolean>
-            </field>
-            <field name="importMode">
-              <string>MERGE</string>
-            </field>
-            <field name="configPath">
-              <string>war:/conf/sites/</string>
-            </field>
-            <field name="portalType">
-              <string>portal</string>
-            </field>
-            <field name="portalName">
-              <string>administration</string>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
-    <component-plugin>
       <name>GlobalSitePermissionsUpgrade</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
@@ -255,56 +211,6 @@
               <collection type="java.util.ArrayList" item-type="java.lang.String">
                 <value>
                   <string>pageTemplates</string>
-                </value>
-              </collection>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
-    <component-plugin>
-      <name>LayoutEditorPagePermissionUpgrade</name>
-      <set-method>addUpgradePlugin</set-method>
-      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
-      <init-params>
-        <value-param>
-          <name>product.group.id</name>
-          <value>org.exoplatform.social</value>
-        </value-param>
-        <value-param>
-          <name>plugin.execution.order</name>
-          <value>120</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.execute.once</name>
-          <value>true</value>
-        </value-param>
-        <value-param>
-          <name>enabled</name>
-          <value>true</value>
-        </value-param>
-        <object-param>
-          <name>global.upgrade</name>
-          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
-            <field name="updatePageLayout">
-              <boolean>true</boolean>
-            </field>
-            <field name="configPath">
-              <string>war:/conf/sites/</string>
-            </field>
-            <field name="portalType">
-              <string>portal</string>
-            </field>
-            <field name="portalName">
-              <string>global</string>
-            </field>
-            <field name="importMode">
-              <string>merge</string>
-            </field>
-            <field name="pageNames">
-              <collection type="java.util.ArrayList" item-type="java.lang.String">
-                <value>
-                  <string>layout-editor</string>
                 </value>
               </collection>
             </field>
@@ -690,46 +596,6 @@
             </field>
             <field name="oldContentId">
               <string>social/ExternalSpacesList</string>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
-    <component-plugin profiles="layout">
-      <name>PublicSitePortalConfigUpgrade</name>
-      <set-method>addUpgradePlugin</set-method>
-      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
-      <init-params>
-        <value-param>
-          <name>product.group.id</name>
-          <value>org.exoplatform.social</value>
-        </value-param>
-        <value-param>
-          <name>plugin.execution.order</name>
-          <value>130</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.execute.once</name>
-          <value>true</value>
-        </value-param>
-        <value-param>
-          <name>enabled</name>
-          <value>true</value>
-        </value-param>
-        <object-param>
-          <name>PublicSite.upgrade</name>
-          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
-            <field name="updatePortalConfig">
-              <boolean>true</boolean>
-            </field>
-            <field name="configPath">
-              <string>war:/conf/sites/</string>
-            </field>
-            <field name="portalType">
-              <string>portal</string>
-            </field>
-            <field name="portalName">
-              <string>public</string>
             </field>
           </object>
         </object-param>
@@ -1791,26 +1657,6 @@
           </object>
         </object-param>
         <object-param>
-          <name>DrawersOverlay</name>
-          <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
-            <field name="modificationType">
-              <string>update</string>
-            </field>
-            <field name="oldContentId">
-              <string>social-portlet/DrawersOverlay</string>
-            </field>
-            <field name="newContentId">
-              <string>social/DrawersOverlay</string>
-            </field>
-            <field name="upgradePages">
-              <boolean>true</boolean>
-            </field>
-            <field name="upgradePortletInstance">
-              <boolean>true</boolean>
-            </field>
-          </object>
-        </object-param>
-        <object-param>
           <name>NotificationAdministration</name>
           <object type="io.meeds.layout.model.ApplicationReferenceUpgrade">
             <field name="modificationType">
@@ -2347,6 +2193,229 @@
             </field>
             <field name="portalName">
               <string>global</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>AdministrationSitePortalConfigUpgrade.1</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <description>An upgrade plugin to delete some recognition administration navigations</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>overview.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePortalConfig">
+              <boolean>true</boolean>
+            </field>
+            <field name="importMode">
+              <string>MERGE</string>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>administration</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin profiles="layout">
+      <name>PublicSitePortalConfigUpgrade.1</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>130</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>PublicSite.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePortalConfig">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>public</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin profiles="layout">
+      <name>PublicSiteTemplatePortalConfigUpgrade.1</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>130</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>PublicSite.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePortalConfig">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal_template</string>
+            </field>
+            <field name="portalName">
+              <string>public</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin profiles="layout">
+      <name>SpacePublicSiteTemplatePortalConfigUpgrade.1</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>130</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>SpacePublicSite.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePortalConfig">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal_template</string>
+            </field>
+            <field name="portalName">
+              <string>spacePublic</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>LayoutEditorsPagesUpgrade.1</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>global.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="importMode">
+              <string>merge</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>site-layout-editor</string>
+                </value>
+                <value>
+                  <string>layout-editor</string>
+                </value>
+                <value>
+                  <string>section-editor</string>
+                </value>
+                <value>
+                  <string>portlet-editor</string>
+                </value>
+              </collection>
             </field>
           </object>
         </object-param>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/portal.xml
@@ -34,53 +34,47 @@
     <entry key="removable">false</entry>
     <entry key="icon">fa-cogs</entry>
   </properties>
-  <portal-layout>
-    <container template="system:/groovy/portal/webui/container/UISimpleTableContainer.gtmpl" cssClass="ma-0">
-      <access-permissions>*:/platform/users</access-permissions>
-      <container template="system:/groovy/portal/webui/container/UIResponsiveColumnGroupContainer.gtmpl">
-        <container template="system:/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl" cssClass="administrationSiteVerticalMenuContainerClass">
-          <access-permissions>*:/platform/users</access-permissions>
+  <portal-layout template="system:/groovy/portal/webui/container/UISiteLayout.gtmpl">
+    <section-sidebar>
+      <sidebar-cell>
+        <portlet-application>
+          <portlet>
+            <application-ref>social</application-ref>
+            <portlet-ref>VerticalMenu</portlet-ref>
+          </portlet>
+          <title>Site Vertical Menu</title>
+        </portlet-application>
+      </sidebar-cell>
+    </section-sidebar>
+    <site-middle-section>
+      <section-banner
+        height="57">
+        <css-style>
+          <margin-top>20</margin-top>
+          <margin-bottom>20</margin-bottom>
+          <margin-right>20</margin-right>
+          <margin-left>20</margin-left>
+        </css-style>
+        <!-- Begin: Left -->
+        <banner-cell width="fit-content">
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
-              <portlet-ref>VerticalMenu</portlet-ref>
+              <portlet-ref>Breadcrumb</portlet-ref>
+              <preferences>
+                <preference>
+                  <name>noThreeDots</name>
+                  <value>true</value>
+                </preference>
+              </preferences>
             </portlet>
-            <title>Site Vertical Menu</title>
-            <access-permissions>*:/platform/users</access-permissions>
-            <show-info-bar>false</show-info-bar>
-            <show-application-state>false</show-application-state>
-            <show-application-mode>false</show-application-mode>
+            <title>Site Breadcrumb application</title>
           </portlet-application>
-          </container>
-        <container template="system:/groovy/portal/webui/container/UISimpleColumnContainer.gtmpl" cssClass="administrationSitePageBodyContainerClass">
-          <access-permissions>*:/platform/users</access-permissions>
-          <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl" cssClass="singlePageApplication">
-            <access-permissions>*:/platform/users</access-permissions>
-            <portlet-application>
-              <portlet>
-                <application-ref>social</application-ref>
-                <portlet-ref>Breadcrumb</portlet-ref>
-                <preferences>
-                  <preference>
-                    <name>noThreeDots</name>
-                    <value>true</value>
-                  </preference>
-                </preferences>
-              </portlet>
-              <title>Site Breadcrumb application</title>
-              <access-permissions>*:/platform/users</access-permissions>
-              <show-info-bar>false</show-info-bar>
-              <show-application-state>false</show-application-state>
-              <show-application-mode>false</show-application-mode>
-            </portlet-application>
-          </container>
-          <page-body> </page-body>
-        </container>
-      </container>
-    </container>
-    <container id="bottom-all-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-      <name>bottom-all-container</name>
-      <factory-id>addonContainer</factory-id>
-    </container>
+        </banner-cell>
+      </section-banner>
+      <site-middle-center-section>
+        <page-body />
+      </site-middle-center-section>
+    </site-middle-section>
   </portal-layout>
 </portal-config>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -1635,21 +1635,6 @@
           </container>
         </container>
       </container>
-      <container
-        id="MiddleToolBar"
-        template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>DrawersOverlay</portlet-ref>
-          </portlet>
-          <title>Drawers Overlay</title>
-        </portlet-application>
-      </container>
-      <container
-        id="TopbarLoadingContainer"
-        template="system:/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl">
-      </container>
     </container>
     <container
       template="system:/groovy/portal/webui/container/UIContainer.gtmpl"
@@ -1686,21 +1671,6 @@
           </container>
         </container>
       </container>
-      <container
-        id="MiddleToolBar"
-        template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>DrawersOverlay</portlet-ref>
-          </portlet>
-          <title>Drawers Overlay</title>
-        </portlet-application>
-      </container>
-      <container
-        id="TopbarLoadingContainer"
-        template="system:/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl">
-      </container>
     </container>
     <container
       template="system:/groovy/portal/webui/container/UIContainer.gtmpl"
@@ -1736,21 +1706,6 @@
             template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
           </container>
         </container>
-      </container>
-      <container
-        id="MiddleToolBar"
-        template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>DrawersOverlay</portlet-ref>
-          </portlet>
-          <title>Drawers Overlay</title>
-        </portlet-application>
-      </container>
-      <container
-        id="TopbarLoadingContainer"
-        template="system:/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl">
       </container>
     </container>
     <container
@@ -2178,21 +2133,6 @@
             template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
           </container>
         </container>
-      </container>
-      <container
-        id="MiddleToolBar"
-        template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>DrawersOverlay</portlet-ref>
-          </portlet>
-          <title>Drawers Overlay</title>
-        </portlet-application>
-      </container>
-      <container
-        id="TopbarLoadingContainer"
-        template="system:/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl">
       </container>
     </container>
     <container

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/portal.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/public/portal.xml
@@ -48,8 +48,6 @@
               <portlet-ref>TopBarLogo</portlet-ref>
             </portlet>
             <title>Company Logo</title>
-            <show-info-bar>false</show-info-bar>
-            <show-application-state>false</show-application-state>
           </portlet-application>
         </banner-cell>
         <banner-cell width="fit-content">
@@ -62,34 +60,36 @@
           </portlet-application>
         </banner-cell>
         <banner-cell width="fit-content">
-          <access-permissions>*:/platform/administrators;publisher:/platform/web-contributors</access-permissions>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
               <portlet-ref>TopBarPreview</portlet-ref>
             </portlet>
             <title>Preview Site Button</title>
-            <show-info-bar>false</show-info-bar>
-            <show-application-state>false</show-application-state>
           </portlet-application>
         </banner-cell>
         <banner-cell width="fit-content">
-          <access-permissions>*:/platform/administrators</access-permissions>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
               <portlet-ref>TopBarPublishSite</portlet-ref>
             </portlet>
             <title>Publish Site Button</title>
-            <show-info-bar>false</show-info-bar>
-            <show-application-state>false</show-application-state>
           </portlet-application>
         </banner-cell>
         <!-- End: Left -->
 
-        <!-- Begin: Spacer -->
-        <banner-cell /><!-- Banner Cell for spacing between left and right -->
-        <!-- End: Spacer -->
+        <!-- Begin: Middle -->
+        <banner-cell>
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>TopBarMenu</portlet-ref>
+            </portlet>
+            <title>Top Bar Menu</title>
+          </portlet-application>
+        </banner-cell>
+        <!-- End: Middle -->
 
         <!-- Begin: Right -->
         <banner-cell width="fit-content">
@@ -99,8 +99,6 @@
               <portlet-ref>TopBarLogin</portlet-ref>
             </portlet>
             <title>Login Button</title>
-            <show-info-bar>false</show-info-bar>
-            <show-application-state>false</show-application-state>
           </portlet-application>
         </banner-cell>
         <!-- End: Right -->

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal_template/public/portal_template.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal_template/public/portal_template.xml
@@ -33,74 +33,77 @@
     <entry key="removable">false</entry>
     <entry key="icon">fa-globe</entry>
   </properties>
-  <portal-layout>
-    <container id="UITopBarContainer" template="system:/groovy/portal/webui/container/UITopBarContainer.gtmpl">
-      <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>TopBarLogo</portlet-ref>
-          </portlet>
-          <title>Company Logo</title>
-          <show-info-bar>false</show-info-bar>
-          <show-application-state>false</show-application-state>
-        </portlet-application>
-      </container>
-      <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl" profiles="layout">
-        <portlet-application>
-          <portlet>
-            <application-ref>layout</application-ref>
-            <portlet-ref>SiteNavigation</portlet-ref>
-          </portlet>
-          <title>Site navigation</title>
-        </portlet-application>
-      </container>
-      <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <access-permissions>*:/platform/administrators;publisher:/platform/web-contributors</access-permissions>
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>TopBarPreview</portlet-ref>
-          </portlet>
-          <title>Preview Site Button</title>
-          <show-info-bar>false</show-info-bar>
-          <show-application-state>false</show-application-state>
-        </portlet-application>
-      </container>
-      <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <access-permissions>*:/platform/administrators</access-permissions>
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>TopBarPublishSite</portlet-ref>
-          </portlet>
-          <title>Publish Site Button</title>
-          <show-info-bar>false</show-info-bar>
-          <show-application-state>false</show-application-state>
-        </portlet-application>
-      </container>
-      <container id="MiddleToolBar" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-        <name>MiddleToolBar</name>
-        <factory-id>addonContainer</factory-id>
-      </container>
-      <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>TopBarLogin</portlet-ref>
-          </portlet>
-          <title>Login Button</title>
-          <show-info-bar>false</show-info-bar>
-          <show-application-state>false</show-application-state>
-        </portlet-application>
-      </container>
-      <container id="TopbarLoadingContainer" template="system:/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl">
-      </container>
-    </container>
-    <page-body />
-    <container id="bottom-all-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-      <name>bottom-all-container</name>
-      <factory-id>addonContainer</factory-id>
-    </container>
+  <portal-layout template="system:/groovy/portal/webui/container/UISiteLayout.gtmpl">
+    <site-middle-section>
+      <section-banner
+        height="57"
+        sticky-beahvior="true">
+        <!-- Begin: Left -->
+        <banner-cell width="fit-content">
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>TopBarLogo</portlet-ref>
+            </portlet>
+            <title>Company Logo</title>
+          </portlet-application>
+        </banner-cell>
+        <banner-cell width="fit-content">
+          <portlet-application>
+            <portlet>
+              <application-ref>layout</application-ref>
+              <portlet-ref>SiteNavigation</portlet-ref>
+            </portlet>
+            <title>Site navigation</title>
+          </portlet-application>
+        </banner-cell>
+        <banner-cell width="fit-content">
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>TopBarPreview</portlet-ref>
+            </portlet>
+            <title>Preview Site Button</title>
+          </portlet-application>
+        </banner-cell>
+        <banner-cell width="fit-content">
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>TopBarPublishSite</portlet-ref>
+            </portlet>
+            <title>Publish Site Button</title>
+          </portlet-application>
+        </banner-cell>
+        <!-- End: Left -->
+
+        <!-- Begin: Middle -->
+        <banner-cell>
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>TopBarMenu</portlet-ref>
+            </portlet>
+            <title>Top Bar Menu</title>
+          </portlet-application>
+        </banner-cell>
+        <!-- End: Middle -->
+
+        <!-- Begin: Right -->
+        <banner-cell width="fit-content">
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>TopBarLogin</portlet-ref>
+            </portlet>
+            <title>Login Button</title>
+          </portlet-application>
+        </banner-cell>
+        <!-- End: Right -->
+      </section-banner>
+      <site-middle-center-section>
+        <page-body />
+      </site-middle-center-section>
+    </site-middle-section>
   </portal-layout>
 </portal-config>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal_template/spacePublic/portal_template.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal_template/spacePublic/portal_template.xml
@@ -9,6 +9,7 @@
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
   version 3 of the License, or (at your option) any later version.
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -30,50 +31,59 @@
     <entry key="removable">false</entry>
     <entry key="icon">fa-layer-group</entry>
   </properties>
-  <portal-layout>
-    <container id="UITopBarContainer" template="system:/groovy/portal/webui/container/UITopBarContainer.gtmpl">
-      <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>TopBarLogo</portlet-ref>
-          </portlet>
-          <title>Space Logo</title>
-          <show-info-bar>false</show-info-bar>
-          <show-application-state>false</show-application-state>
-        </portlet-application>
-      </container>
-      <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl" profiles="layout">
-        <portlet-application>
-          <portlet>
-            <application-ref>layout</application-ref>
-            <portlet-ref>SiteNavigation</portlet-ref>
-          </portlet>
-          <title>Site navigation</title>
-        </portlet-application>
-      </container>
-      <container id="MiddleToolBar" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-        <name>MiddleToolBar</name>
-        <factory-id>addonContainer</factory-id>
-      </container>
-      <container template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
-        <portlet-application>
-          <portlet>
-            <application-ref>social</application-ref>
-            <portlet-ref>TopBarLogin</portlet-ref>
-          </portlet>
-          <title>Login Button</title>
-          <show-info-bar>false</show-info-bar>
-          <show-application-state>false</show-application-state>
-        </portlet-application>
-      </container>
-      <container id="TopbarLoadingContainer" template="system:/groovy/portal/webui/container/UITopbarLoadingContainer.gtmpl">
-      </container>
-    </container>
-    <page-body />
-    <container id="bottom-all-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-      <name>bottom-all-container</name>
-      <factory-id>addonContainer</factory-id>
-    </container>
+  <portal-layout template="system:/groovy/portal/webui/container/UISiteLayout.gtmpl">
+    <site-middle-section>
+      <section-banner
+        height="57"
+        sticky-beahvior="true">
+        <!-- Begin: Left -->
+        <banner-cell width="fit-content">
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>TopBarLogo</portlet-ref>
+            </portlet>
+            <title>Space Logo</title>
+          </portlet-application>
+        </banner-cell>
+        <banner-cell width="fit-content">
+          <portlet-application>
+            <portlet>
+              <application-ref>layout</application-ref>
+              <portlet-ref>SiteNavigation</portlet-ref>
+            </portlet>
+            <title>Site navigation</title>
+          </portlet-application>
+        </banner-cell>
+        <!-- End: Left -->
+
+        <!-- Begin: Middle -->
+        <banner-cell>
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>TopBarMenu</portlet-ref>
+            </portlet>
+            <title>Top Bar Menu</title>
+          </portlet-application>
+        </banner-cell>
+        <!-- End: Middle -->
+
+        <!-- Begin: Right -->
+        <banner-cell width="fit-content">
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>TopBarLogin</portlet-ref>
+            </portlet>
+            <title>Login Button</title>
+          </portlet-application>
+        </banner-cell>
+        <!-- End: Right -->
+      </section-banner>
+      <site-middle-center-section>
+        <page-body />
+      </site-middle-center-section>
+    </site-middle-section>
   </portal-layout>
 </portal-config>


### PR DESCRIPTION
This change will allow to centralize the system apps and divs to be served by `UIPortalApplication` rather than AddonContainers added inside the `sharedlayout.xml` and `portal.xml` of standalone sites. In addition, this change will upgrade the Builtin site layouts to use new Site Layout Definition.