### PR TITLE
fix: org chart & My Team pages should not be available for externals - Meeds-io/meeds#112 - EXO-71284

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -1703,7 +1703,7 @@
   <page>
     <name>organizationalchart</name>
     <title>Organizational Chart</title>
-    <access-permissions>Everyone</access-permissions>
+    <access-permissions>*:/platform/users</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>
     <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
       <section-columns>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/mycraft/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/mycraft/pages.xml
@@ -128,7 +128,7 @@
   <page>
     <name>myteam</name>
     <title>My Team</title>
-    <access-permissions>Everyone</access-permissions>
+    <access-permissions>*:/platform/users</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>
     <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
       <section-columns>


### PR DESCRIPTION
Before this fix, the access permissions for pages myteam and orgchart where changed only in develop-exo, the backport on develop was missing This PR adapts and ensure the backport

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - Meeds-io/MIPs#1234
or
fix: Fix TITLE - MEED-XXXX - Meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
