### PR TITLE
fix: Add "news-editor" and remove "news/news-editor" navigation nodes of global site - MEED-8425

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -2527,5 +2527,52 @@
         </object-param>
       </init-params>
     </component-plugin>
+	<component-plugin>
+      <name>GlobalSiteNewsEditorNavigationUpdate</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>global.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updateNavigation">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="deleteNavigations">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>news/editor</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/navigation.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/navigation.xml
@@ -331,13 +331,13 @@
       <label>#{news.navigation.node.label}</label>
       <visibility>SYSTEM</visibility>
       <page-reference>portal::global::news</page-reference>
-      <node>
-        <name>editor</name>
+    </node>
+	<node>
+        <name>news-editor</name>
         <label>#{portal.global.newsEditor}</label>
         <visibility>SYSTEM</visibility>
         <page-reference>portal::global::newsComposer</page-reference>
       </node>
-    </node>
     <node>
       <name>analytics</name>
       <label>#{analytics.navigation.Analytics}</label>


### PR DESCRIPTION

Prior to this change, "news/news-editor" navigation node of global site was not accessible to guests even if they are in related page access permissions since the parent navigation node "news" is not accessible to them. In order to allow guest to access to news editor, we have removed the "news/news-editor" navigation node and created the root navigation node "news-editor" instead.