### PR TITLE
fix: Change Pages Access permissions expression - MEED-8472 - Meeds-io/meeds#2999

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -165,60 +165,6 @@
       </init-params>
     </component-plugin>
     <component-plugin>
-      <name>AdministrationPageTemplatesNavigation</name>
-      <set-method>addUpgradePlugin</set-method>
-      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
-      <description>An upgrade plugin to import newly introduced page templates administration page</description>
-      <init-params>
-        <value-param>
-          <name>product.group.id</name>
-          <value>org.exoplatform.social</value>
-        </value-param>
-        <value-param>
-          <name>plugin.execution.order</name>
-          <value>120</value>
-        </value-param>
-        <value-param>
-          <name>plugin.upgrade.execute.once</name>
-          <value>true</value>
-        </value-param>
-        <value-param>
-          <name>enabled</name>
-          <value>true</value>
-        </value-param>
-        <object-param>
-          <name>administration.pages.upgrade</name>
-          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
-            <field name="updateNavigation">
-              <boolean>true</boolean>
-            </field>
-            <field name="updatePageLayout">
-              <boolean>true</boolean>
-            </field>
-            <field name="importMode">
-              <string>MERGE</string>
-            </field>
-            <field name="configPath">
-              <string>war:/conf/sites/</string>
-            </field>
-            <field name="portalType">
-              <string>portal</string>
-            </field>
-            <field name="portalName">
-              <string>administration</string>
-            </field>
-            <field name="pageNames">
-              <collection type="java.util.ArrayList" item-type="java.lang.String">
-                <value>
-                  <string>pageTemplates</string>
-                </value>
-              </collection>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
-    <component-plugin>
       <name>RecognitionSetupApplicationsLayoutUpgrade</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
@@ -2520,6 +2466,65 @@
               <collection type="java.util.ArrayList" item-type="java.lang.String">
                 <value>
                   <string>news/editor</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>AdministrationPagesPermissionsUpdate</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>administration.pages.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="importMode">
+              <string>MERGE</string>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>administration</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>pageTemplates</string>
+                </value>
+                <value>
+                  <string>portlets</string>
+                </value>
+                <value>
+                  <string>siteTemplates</string>
+                </value>
+                <value>
+                  <string>sectionTemplates</string>
                 </value>
               </collection>
             </field>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/pages.xml
@@ -547,7 +547,6 @@
               <application-ref>layout</application-ref>
               <portlet-ref>SiteManagement</portlet-ref>
             </portlet>
-            <access-permissions>Everyone</access-permissions>
           </portlet-application>
         </column>
       </section-columns>
@@ -711,7 +710,7 @@
   <page profiles="layout">
     <name>pageTemplates</name>
     <title>Page Templates Management</title>
-    <access-permissions>*:/platform/administrators,manager:/platform/web-contributors</access-permissions>
+    <access-permissions>*:/platform/administrators;manager:/platform/web-contributors</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>
     <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
       <section-columns>
@@ -731,7 +730,7 @@
   <page profiles="layout">
     <name>portlets</name>
     <title>Portlets</title>
-    <access-permissions>*:/platform/administrators,manager:/platform/web-contributors</access-permissions>
+    <access-permissions>*:/platform/administrators;manager:/platform/web-contributors</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>
     <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
       <section-columns>
@@ -751,7 +750,7 @@
   <page profiles="layout">
     <name>siteTemplates</name>
     <title>Site Templates</title>
-    <access-permissions>*:/platform/administrators,manager:/platform/web-contributors</access-permissions>
+    <access-permissions>*:/platform/administrators;manager:/platform/web-contributors</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>
     <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
       <section-columns>
@@ -771,7 +770,7 @@
   <page profiles="layout">
     <name>sectionTemplates</name>
     <title>Section Templates</title>
-    <access-permissions>*:/platform/administrators,manager:/platform/web-contributors</access-permissions>
+    <access-permissions>*:/platform/administrators;manager:/platform/web-contributors</access-permissions>
     <edit-permission>manager:/platform/administrators</edit-permission>
     <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
       <section-columns>


### PR DESCRIPTION
Prior to this change, the access permissions of some pages are using ',' as separator rather than ';'. This change uses the right separator.

Resolves Meeds-io/meeds#2999