### PR TITLE
fix: Update manage news targets page permissions - MEED-8651 - #3150

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -273,6 +273,56 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin profiles="content">
+      <name>ContentTargetsPagePermissionsUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>140</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>global.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>administration</string>
+            </field>
+            <field name="importMode">
+              <string>merge</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>newsTargets</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
     <component-plugin>
       <name>GlobalSiteNavigationUpdate</name>
       <set-method>addUpgradePlugin</set-method>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/pages.xml
@@ -690,8 +690,8 @@
   <page profiles="content">
     <name>newsTargets</name>
     <title>News targets</title>
-    <access-permissions>manager:/platform/web-contributors</access-permissions>
-    <edit-permission>manager:/platform/web-contributors</edit-permission>
+    <access-permissions>*:/platform/administrators</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
     <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
       <section-columns>
         <column col-span="12">


### PR DESCRIPTION
This change is going remove web-contributor permission from news target administration page
