### PR TITLE
fix: Avoid changing Manifest Location - MEED-8638 - Meeds-io/MIPs#185

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/externalRegistration/init_account.jsp
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/externalRegistration/init_account.jsp
@@ -75,7 +75,7 @@
   <meta name="theme-color" content="<%=pwaManifestService.getThemeColor()%>"/>
 <%
   if (pwaManifestService.isPwaEnabled()) {
-%><link rel="manifest" href="<%="/pwa/rest/manifest?v=" + pwaManifestService.getManifestHash()%>"><%
+%><link rel="manifest" href="<%="/pwa/rest/manifest"%>"><%
   }
 %>
   <!-- Preload Styles & Fonts & Scripts for HTTP/2 optimizations -->

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/forgotpassword/forgot_password.jsp
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/forgotpassword/forgot_password.jsp
@@ -75,7 +75,7 @@
   <meta name="theme-color" content="<%=pwaManifestService.getThemeColor()%>"/>
 <%
   if (pwaManifestService.isPwaEnabled()) {
-%><link rel="manifest" href="<%="/pwa/rest/manifest?v=" + pwaManifestService.getManifestHash()%>"><%
+%><link rel="manifest" href="<%="/pwa/rest/manifest"%>"><%
   }
 %><!-- Preload Styles & Fonts & Scripts for HTTP/2 optimizations -->
   <link rel="preload" href="/platform-ui/skin/fonts/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2" as="font" type="font/woff2" crossorigin />

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/login/login.jsp
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/login/login.jsp
@@ -70,7 +70,7 @@
   <meta name="theme-color" content="<%=pwaManifestService.getThemeColor()%>"/>
 <%
   if (pwaManifestService.isPwaEnabled()) {
-%><link rel="manifest" href="<%="/pwa/rest/manifest?v=" + pwaManifestService.getManifestHash()%>"><%
+%><link rel="manifest" href="<%="/pwa/rest/manifest"%>"><%
   }
 %>
   <!-- Preload Styles & Fonts & Scripts for HTTP/2 optimizations -->

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/onboarding/reset_password.jsp
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/onboarding/reset_password.jsp
@@ -75,7 +75,7 @@
   <meta name="theme-color" content="<%=pwaManifestService.getThemeColor()%>"/>
 <%
   if (pwaManifestService.isPwaEnabled()) {
-%><link rel="manifest" href="<%="/pwa/rest/manifest?v=" + pwaManifestService.getManifestHash()%>"><%
+%><link rel="manifest" href="<%="/pwa/rest/manifest"%>"><%
   }
 %>
   <!-- Preload Styles & Fonts & Scripts for HTTP/2 optimizations -->

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/register/register.jsp
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/jsp/register/register.jsp
@@ -70,7 +70,7 @@
   <meta name="theme-color" content="<%=pwaManifestService.getThemeColor()%>"/>
 <%
   if (pwaManifestService.isPwaEnabled()) {
-%><link rel="manifest" href="<%="/pwa/rest/manifest?v=" + pwaManifestService.getManifestHash()%>"><%
+%><link rel="manifest" href="<%="/pwa/rest/manifest"%>"><%
   }
 %>
   <!-- Preload Styles & Fonts & Scripts for HTTP/2 optimizations -->


### PR DESCRIPTION
Prior to this change, the Manifest location changes when an admin changes its properties. This change ensures to use the same location all time to ensure compatibility with all browsers.