### PR TITLE
fix: Update Notes Editor Layout Definition - MEED-9310 - Meeds-io/meeds#3423

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -2469,6 +2469,56 @@
       </init-params>
     </component-plugin>
     <component-plugin>
+      <name>NotesEditorPagesUpgrade-7.0</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>global.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="importMode">
+              <string>merge</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>notes-editor</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
       <name>GlobalSiteNewsEditorNavigationUpdate</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -685,20 +685,14 @@
     <edit-permission>manager:/platform/administrators</edit-permission>
     <show-max-window>true</show-max-window>
     <hide-shared-layout>true</hide-shared-layout>
-    <container id="top-notes-editor-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-      <name>top-notes-editor-container</name>
-      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
-      <factory-id>addonContainer</factory-id>
-    </container>
-    <container id="notes-editor-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-      <name>notes-editor-container</name>
-      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
-      <factory-id>addonContainer</factory-id>
-    </container>
-    <container id="bottom-notes-editor-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-      <name>bottom-notes-editor-container</name>
-      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
-      <factory-id>addonContainer</factory-id>
+    <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
+      <portlet-application>
+        <portlet>
+          <application-ref>notes</application-ref>
+          <portlet-ref>NotesEditor</portlet-ref>
+        </portlet>
+        <title>Notes Editor Application</title>
+      </portlet-application>
     </container>
   </page>
 
@@ -867,10 +861,6 @@
           </portlet-application>
         </column>
       </section-columns>
-    </container>
-    <container id="bottom-news-composer-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
-      <name>bottom-news-composer-container</name>
-      <factory-id>addonContainer</factory-id>
     </container>
   </page>
 


### PR DESCRIPTION
Prior to this change, the Notes Editor was using Addon Containers inside its definition. This change ensures to use the new Layout Manager definition in order to make it easier to maintain. At the same time, in 7.0.x, no Update Plugin has been added to force upgrade Notes Editor Layout, especially using the flag
<hide-shared-layout>true</hide-shared-layout> which make the page not displayed the same way when upgrading from 6.x and having a fresh new server data.

At the same time, this will delete the unused addon container `bottom-news-composer-container`.

Resolves Meeds-io/meeds#3423