### PR TITLE
feat: Drop digest Web Archive - exoplatform/exip#21

### DIFF
--- a/packaging/plf-dependencies/pom.xml
+++ b/packaging/plf-dependencies/pom.xml
@@ -52,18 +52,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>io.meeds.portal</groupId>
-      <artifactId>portal.web.digest</artifactId>
-      <type>war</type>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!-- Commons -->
     <dependency>
       <groupId>io.meeds.commons</groupId>

--- a/packaging/plf-tomcat-resources/src/main/resources/conf/jaas.conf
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/jaas.conf
@@ -18,11 +18,3 @@ gatein-domain {
     portalContainerName=portal
     realmName=gatein-domain;
 };
-digest-domain {
-  org.exoplatform.web.login.FilterDisabledLoginModule required
-    portalContainerName=portal
-    realmName=digest-domain;
-  io.meeds.web.security.authenticator.DigestLoginModule required
-    portalContainerName=portal
-    realmName=digest-domain;
-};

--- a/services/plf-configuration/src/main/resources/conf/platform/configuration.xml
+++ b/services/plf-configuration/src/main/resources/conf/platform/configuration.xml
@@ -71,9 +71,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                   <string>rest</string>
                </value>
                <value>
-                  <string>digest</string>
-               </value>
-               <value>
                   <string>commons-extension</string>
                </value>
                <value>


### PR DESCRIPTION
This change will drop the use of 'digest' archive, now that we don't need it with the API Key Framework.