### PR TITLE
feat: Drop digest Web Archive - exoplatform/exip#21

### DIFF
--- a/packaging/plf-dependencies/pom.xml
+++ b/packaging/plf-dependencies/pom.xml
@@ -52,18 +52,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>io.meeds.portal</groupId>
-      <artifactId>portal.web.digest</artifactId>
-      <type>war</type>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!-- Commons -->
     <dependency>
       <groupId>io.meeds.commons</groupId>

--- a/packaging/plf-tomcat-resources/src/main/resources/conf/jaas.conf
+++ b/packaging/plf-tomcat-resources/src/main/resources/conf/jaas.conf
@@ -18,11 +18,3 @@ gatein-domain {
     portalContainerName=portal
     realmName=gatein-domain;
 };
-digest-domain {
-  org.exoplatform.web.login.FilterDisabledLoginModule required
-    portalContainerName=portal
-    realmName=digest-domain;
-  io.meeds.web.security.authenticator.DigestLoginModule required
-    portalContainerName=portal
-    realmName=digest-domain;
-};

--- a/services/plf-configuration/src/main/resources/conf/platform/configuration.xml
+++ b/services/plf-configuration/src/main/resources/conf/platform/configuration.xml
@@ -71,9 +71,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                   <string>rest</string>
                </value>
                <value>
-                  <string>digest</string>
-               </value>
-               <value>
                   <string>commons-extension</string>
                </value>
                <value>

--- a/webapps/plf-root-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapps/plf-root-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,30 +1,50 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 <!--
-This file is part of the Meeds project (https://meeds.io/).
-Copyright (C) 2020 Meeds Association
-contact@meeds.io
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-You should have received a copy of the GNU Lesser General Public License
-along with this program; if not, write to the Free Software Foundation,
-Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2020 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 -->
 <web-app
-    version="3.0"
-    metadata-complete="true"
-    xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+  version="3.0"
+  metadata-complete="true"
+  xmlns="http://java.sun.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+  <absolute-ordering />
 
-  <display-name>Welcome to eXo platform</display-name>
-  <description>Welcome to eXo platform</description>
+  <filter>
+    <filter-name>PortalContainerFilter</filter-name>
+    <filter-class>org.exoplatform.container.web.PortalContainerFilter</filter-class>
+  </filter>
 
-  <absolute-ordering/>
+  <filter>
+    <filter-name>RootWebappFilter</filter-name>
+    <filter-class>io.meeds.web.security.filter.RootWebappFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>PortalContainerFilter</filter-name>
+    <url-pattern>*</url-pattern>
+  </filter-mapping>
+
+  <filter-mapping>
+    <filter-name>RootWebappFilter</filter-name>
+    <url-pattern>*</url-pattern>
+  </filter-mapping>
+
 </web-app>

--- a/webapps/plf-root-webapp/src/main/webapp/index.jsp
+++ b/webapps/plf-root-webapp/src/main/webapp/index.jsp
@@ -1,37 +1,21 @@
-<!--
-This file is part of the Meeds project (https://meeds.io/).
-Copyright (C) 2020 Meeds Association
-contact@meeds.io
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-You should have received a copy of the GNU Lesser General Public License
-along with this program; if not, write to the Free Software Foundation,
-Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
--->
 <%--
 
-    Copyright (C) 2003-2013 eXo Platform SAS.
+  This file is part of the Meeds project (https://meeds.io/).
+  Copyright (C) 2020 Meeds Association contact@meeds.io
 
-    This is free software; you can redistribute it and/or modify it
-    under the terms of the GNU Lesser General Public License as
-    published by the Free Software Foundation; either version 3 of
-    the License, or (at your option) any later version.
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
 
-    This software is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-    Lesser General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public
-    License along with this software; if not, write to the Free
-    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 --%>
 <%


### PR DESCRIPTION
This change will drop the use of 'digest' archive, now that we don't need it with the API Key Framework.

Resolves exoplatform/exip#21