### PR TITLE
feat: Limit the doc size of versions - EXO-81797 - Meeds-io/meeds#3755

### DIFF
--- a/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
+++ b/services/plf-configuration/src/main/resources/conf/platform/configuration.properties
@@ -361,7 +361,7 @@ exo.remote-edit.powerpoint.ico=${exo.remote-edit.powerpoint.ico:uiIcon16x16appli
 # Document Auto Versioning
 #
 jcr.documents.versioning.drives=${exo.ecms.documents.versioning.drives:Managed Sites,Groups,Personal Documents}
-jcr.documents.versions.max=${exo.ecms.documents.versions.max:0}
+jcr.documents.versions.max=${exo.ecms.documents.versions.max:25}
 jcr.documents.versions.expiration=${exo.ecms.documents.versions.expiration:0}
 
 


### PR DESCRIPTION
This Commit sets the default value of maximum number of version per documents to 25.