### PR TITLE
fix: Update login pages margin and size - MEED-9838 - meeds-io/meeds#3779

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -1049,7 +1049,7 @@
             <title>Platform Name</title>
             <height>150</height>
             <css-style>
-              <margin-top>60</margin-top>
+              <margin-top>20</margin-top>
               <margin-bottom>0</margin-bottom>
               <margin-right>20</margin-right>
               <margin-left>20</margin-left>
@@ -1079,7 +1079,7 @@
             </portlet>
             <title>Login Form</title>
              <css-style>
-                <margin-top>0</margin-top>
+                <margin-top>-40</margin-top>
                 <margin-bottom>20</margin-bottom>
                 <margin-right>20</margin-right>
                 <margin-left>20</margin-left>
@@ -1098,7 +1098,7 @@
               </preferences>
             </portlet>
             <title>Platform Logo</title>
-            <height>100</height>
+            <height>50</height>
             <css-style>
               <margin-top>20</margin-top>
               <margin-bottom>40</margin-bottom>
@@ -1166,7 +1166,7 @@
             <title>Platform Name</title>
             <height>150</height>
             <css-style>
-              <margin-top>60</margin-top>
+              <margin-top>20</margin-top>
               <margin-bottom>0</margin-bottom>
               <margin-right>20</margin-right>
               <margin-left>20</margin-left>
@@ -1196,7 +1196,7 @@
             </portlet>
             <title>External Registration</title>
             <css-style>
-              <margin-top>0</margin-top>
+              <margin-top>-40</margin-top>
               <margin-bottom>20</margin-bottom>
               <margin-right>20</margin-right>
               <margin-left>20</margin-left>
@@ -1283,7 +1283,7 @@
             <title>Platform Name</title>
             <height>150</height>
             <css-style>
-              <margin-top>60</margin-top>
+              <margin-top>20</margin-top>
               <margin-bottom>0</margin-bottom>
               <margin-right>20</margin-right>
               <margin-left>20</margin-left>
@@ -1313,7 +1313,7 @@
             </portlet>
             <title>Forgot Password</title>
             <css-style>
-              <margin-top>0</margin-top>
+              <margin-top>-40</margin-top>
               <margin-bottom>20</margin-bottom>
               <margin-right>20</margin-right>
               <margin-left>20</margin-left>
@@ -1332,7 +1332,7 @@
               </preferences>
             </portlet>
             <title>Platform Logo</title>
-            <height>100</height>
+            <height>50</height>
             <css-style>
               <margin-top>20</margin-top>
               <margin-bottom>40</margin-bottom>
@@ -1400,7 +1400,7 @@
             <title>Platform Name</title>
             <height>150</height>
             <css-style>
-              <margin-top>60</margin-top>
+              <margin-top>20</margin-top>
               <margin-bottom>0</margin-bottom>
               <margin-right>20</margin-right>
               <margin-left>20</margin-left>
@@ -1430,7 +1430,7 @@
             </portlet>
             <title>Internal Registration</title>
             <css-style>
-              <margin-top>0</margin-top>
+              <margin-top>-40</margin-top>
               <margin-bottom>20</margin-bottom>
               <margin-right>20</margin-right>
               <margin-left>20</margin-left>
@@ -1449,7 +1449,7 @@
               </preferences>
             </portlet>
             <title>Platform Logo</title>
-            <height>100</height>
+            <height>50</height>
             <css-style>
               <margin-top>20</margin-top>
               <margin-bottom>40</margin-bottom>
@@ -1517,7 +1517,7 @@
             <title>Platform Name</title>
             <height>150</height>
             <css-style>
-              <margin-top>60</margin-top>
+              <margin-top>20</margin-top>
               <margin-bottom>0</margin-bottom>
               <margin-right>20</margin-right>
               <margin-left>20</margin-left>
@@ -1547,7 +1547,7 @@
             </portlet>
             <title>Register Form</title>
             <css-style>
-              <margin-top>0</margin-top>
+              <margin-top>-40</margin-top>
               <margin-bottom>20</margin-bottom>
               <margin-right>20</margin-right>
               <margin-left>20</margin-left>
@@ -1566,7 +1566,7 @@
               </preferences>
             </portlet>
             <title>Platform Logo</title>
-            <height>100</height>
+            <height>50</height>
             <css-style>
               <margin-top>20</margin-top>
               <margin-bottom>40</margin-bottom>


### PR DESCRIPTION
This commit update the size of platformLogo for pages related to login It also update margins for differents portlets on pages related to login

Resolves meeds-io/meeds#3779

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - Meeds-io/MIPs#1234
or
fix: Fix TITLE - MEED-XXXX - Meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
