### PR TITLE
fix: make insermode=conserve for sites meeds, mycraft, and space_templates - MEED-9953 - meeds-io/meeds#3803

### DIFF
--- a/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal-configuration.xml
+++ b/webapps/plf-meeds-extension/src/main/webapp/WEB-INF/conf/meeds/portal-configuration.xml
@@ -53,7 +53,7 @@
               <boolean>${io.meeds.meeds.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${io.meeds.meeds.portalConfig.metadata.importmode:insert}</string>
+              <string>${io.meeds.meeds.portalConfig.metadata.importmode:conserve}</string>
             </field>
             <field name="location">
               <string>war:/conf/meeds/</string>
@@ -84,7 +84,7 @@
               <boolean>${io.meeds.mycraft.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${io.meeds.mycraft.portalConfig.metadata.importmode:insert}</string>
+              <string>${io.meeds.mycraft.portalConfig.metadata.importmode:conserve}</string>
             </field>
             <field name="location">
               <string>war:/conf/meeds/</string>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-configuration.xml
@@ -222,7 +222,7 @@
               <boolean>${io.meeds.spaceTemplates.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${io.meeds.spaceTemplates.portalConfig.metadata.importmode:insert}</string>
+              <string>${io.meeds.spaceTemplates.portalConfig.metadata.importmode:conserve}</string>
             </field>
           </object>
         </object-param>


### PR DESCRIPTION
Before this fix, when removing a page in the navigation of site meeds, or mycraft or in space template, the page is recreated at startup To prevent this, we change the default configuration for importMode to use "conserve", so that removed page is not recreated.

Resolves meeds-io/meeds#3803

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - Meeds-io/MIPs#1234
or
fix: Fix TITLE - MEED-XXXX - Meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
