### PR TITLE
fix : Make OIDC logout working when end_session_endpoint is present in configuration - MEED-10192 - meeds-io/meeds#4024

### DIFF
--- a/packaging/plf-packaging-resources/src/main/resources/controller.xml
+++ b/packaging/plf-packaging-resources/src/main/resources/controller.xml
@@ -54,6 +54,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </route-param>
   </route>
 
+
+  <route path="/logout">
+    <route-param qname="gtn:handler">
+      <value>logout</value>
+    </route-param>
+  </route>
+
   <route path="/download">
     <route-param qname="gtn:handler">
       <value>download</value>


### PR DESCRIPTION
Before this fix, when using OIDC, some IDP provide a endsession_endpoint url, to make a logout on the IDP after being loggued out from the SP, and eXo do not use this url This commit ensure to send the user in this url if existing and if property exo.oauth.openid.propagate.logout is set to true To achieve this modification, this commit create a new handler in the platform to manage the logout : LogoutHandler on /portal/logout. The old logout code (UIPortal.LogoutActionListener) is removed

Resolves meeds-io/meeds#4024

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - Meeds-io/MIPs#1234
or
fix: Fix TITLE - MEED-XXXX - Meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
