### PR TITLE
fix: restricted page need to be displayed if not allowed to display task - MEED-10264 - Meeds-io/meeds#4060

### DIFF
--- a/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/global_en.properties
@@ -65,3 +65,4 @@ portal.global.external-registration=Guest registration
 portal.global.login=Login
 portal.global.forgot-password=Forgot Password
 portal.global.on-boarding=Create a password
+portal.global.restricted-projec=Restricted Project

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/navigation.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/navigation.xml
@@ -80,6 +80,13 @@
       <visibility>SYSTEM</visibility>
       <page-reference>portal::global::tasks</page-reference>
     </node>
+    
+    <node>
+        <name>restricted-project</name>
+        <label>#{portal.global.restricted-project}</label>
+        <visibility>SYSTEM</visibility>
+        <page-reference>portal::global::restricted-project</page-reference>
+    </node>
 
     <node>
       <name>connexions</name>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -161,6 +161,26 @@
       </section-columns>
     </container>
   </page>
+  
+  <page>
+      <name>restricted-project</name>
+      <title>restricted-project</title>
+      <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
+      <edit-permission>manager:/platform/administrators</edit-permission>
+      <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
+          <section-columns>
+              <column col-span="12">
+                  <portlet-application>
+                      <portlet>
+                          <application-ref>task-management</application-ref>
+                          <portlet-ref>RestrictedProject</portlet-ref>
+                      </portlet>
+                      <title>Restricted Project</title>
+                  </portlet-application>
+              </column>
+          </section-columns>
+      </container>
+  </page>
 
   <page>
     <name>settings</name>


### PR DESCRIPTION
Before this change, if no longer belongs to an accessible project, task url displays blank content. After this change, the restricted page displays correctly, and its URL should be /restricted-project.