### PR TITLE
fix: Fix Notes editor application display issue in edit layout mode - EXO-87312

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -3068,5 +3068,58 @@
         </object-param>
       </init-params>
     </component-plugin>
+	<component-plugin>
+      <name>NotesEditorPagesUpgrade-7.2</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>140</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>global.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="importMode">
+              <string>merge</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>notes-editor</string>
+                </value>
+				<value>
+                  <string>newsComposer</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -705,14 +705,24 @@
     <edit-permission>manager:/platform/administrators</edit-permission>
     <show-max-window>true</show-max-window>
     <hide-shared-layout>true</hide-shared-layout>
-    <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
-      <portlet-application>
-        <portlet>
-          <application-ref>notes</application-ref>
-          <portlet-ref>NotesEditor</portlet-ref>
-        </portlet>
-        <title>Notes Editor Application</title>
-      </portlet-application>
+    <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl" width="100%">
+	   <css-style>
+        <margin-top>0</margin-top>
+        <margin-bottom>0</margin-bottom>
+        <margin-right>0</margin-right>
+        <margin-left>0</margin-left>
+      </css-style>
+	  <section-columns>
+        <column col-span="12">
+          <portlet-application>
+            <portlet>
+              <application-ref>notes</application-ref>
+              <portlet-ref>NotesEditor</portlet-ref>
+            </portlet>
+            <title>Notes Editor Application</title>
+          </portlet-application>
+        </column>
+      </section-columns>
     </container>
   </page>
 
@@ -869,7 +879,13 @@
     <edit-permission>manager:/platform/administrators</edit-permission>
     <show-max-window>true</show-max-window>
     <hide-shared-layout>true</hide-shared-layout>
-    <container cssClass="contentEditorContainer" template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
+    <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl" width="100%">
+      <css-style>
+        <margin-top>0</margin-top>
+        <margin-bottom>0</margin-bottom>
+        <margin-right>0</margin-right>
+        <margin-left>0</margin-left>
+      </css-style>
       <section-columns>
         <column col-span="12">
           <portlet-application>


### PR DESCRIPTION
Prior to this change, the Notes editor application is not well displayed centered in edit layout mode.
After this commit, some css changes are done in order to adjust the display position of the the Notes editor application.