### PR TITLE
fix: pin mcp-server to ai-contribution SNAPSHOT so #12/#13 tools deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <addon.meeds.auth-server.id>meeds-auth-server</addon.meeds.auth-server.id>
     <addon.meeds.auth-server.version>7.3.x-SNAPSHOT</addon.meeds.auth-server.version>
     <addon.meeds.mcp-server.id>meeds-mcp-server</addon.meeds.mcp-server.id>
-    <addon.meeds.mcp-server.version>7.3.x-SNAPSHOT</addon.meeds.mcp-server.version>
+    <addon.meeds.mcp-server.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.mcp-server.version>
     <addon.meeds.matrix.id>meeds-matrix</addon.meeds.matrix.id>
     <addon.meeds.matrix.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.matrix.version>
     <!-- Add-on manager extension to use (empty for Unix, .bat for Windows) -->


### PR DESCRIPTION
## Problem

On the acceptance server (`ai-contribution-ft.meeds.io`) the mcp-server MCP tools added by **[mcp-server#12](https://github.com/Meeds-io/mcp-server/pull/12)** (notifications, connections, spaces, settings, favorites, tags, platform info) and **[mcp-server#13](https://github.com/Meeds-io/mcp-server/pull/13)** (media/image tools) are missing. A live `tools/list` shows only the **38 baseline** mcp-server tools; **61** tools from #12/#13 are absent — even though #12 merged over a day ago.

## Root cause

In this distribution's `pom.xml`, every addon is pinned to `7.3.x-ai-contribution-SNAPSHOT` **except `mcp-server`**, which was left on the plain `7.3.x-SNAPSHOT` (develop) line:

```diff
- <addon.meeds.mcp-server.version>7.3.x-SNAPSHOT</addon.meeds.mcp-server.version>
+ <addon.meeds.mcp-server.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.mcp-server.version>
```

`mcp-server`'s `feature/ai-contribution` branch is **15 commits ahead** of develop (that's where #12/#13 live), so pulling `7.3.x-SNAPSHOT` ships a pre-#12 build.

## Verification

- The `io.meeds.mcp-server:mcp-server:7.3.x-ai-contribution-SNAPSHOT` artifact **is already in Nexus** — buildNumber 20, published 2026-07-10 22:45:56 UTC (2 min after #13 merged), so it includes #12 and #13. This one-line pin is all that's needed.
- `auth-server` is intentionally left on `7.3.x-SNAPSHOT`: its `feature/ai-contribution` branch has **no changes** over develop (1 commit = branch setup only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)