### PR TITLE
fix: Remove stale spaces pages from organization and templates -EXO-88527 - eXIP7.3.0.9

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/navigation.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/administration/navigation.xml
@@ -75,12 +75,6 @@
           <icon>fas fa-user-cog</icon>
           <page-reference>portal::administration::profileManagement</page-reference>
         </node>
-        <node>
-          <name>spaces</name>
-          <label>#{portal.administration.spaces}</label>
-          <icon>fas fa-people-arrows</icon>
-          <page-reference>portal::administration::spacesAdministration</page-reference>
-        </node>
       </node>
       <node>
         <name>applications</name>
@@ -194,12 +188,6 @@
           <name>template</name>
           <label>#{portal.administration.template}</label>
           <icon>fas fa-columns</icon>
-          <node>
-            <name>spaceTemplates</name>
-            <label>#{portal.administration.spaceTemplates}</label>
-            <icon>fas fa-users-cog</icon>
-            <page-reference>portal::administration::spaceTemplates</page-reference>
-          </node>
           <node>
             <name>sites</name>
             <label>#{portal.administration.sites}</label>


### PR DESCRIPTION
Prior to this change, the `sites` module declared its own `spaces` page under `organisation` and `spaceTemplates` page under `template`, even though those pages were already moved into a new grouped `Spaces` navigation entry in `digital-workplace`. Because `sites` still declared them, they were never orphans, so they kept reappearing after every restore no matter what.
This change will remove those two stale declarations from `sites`, so the pages exist only in their new grouped location and restoring default pages can correctly clean them up on any platform still carrying the old entries.