### PR TITLE
feat: route the profile pages through the profile access check - EXO-89280

### DIFF
--- a/packaging/plf-packaging-resources/src/main/resources/controller.xml
+++ b/packaging/plf-packaging-resources/src/main/resources/controller.xml
@@ -240,6 +240,22 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </path-param>
   </route>
 
+  <!-- The profile owner access check -->
+  <route path="/{gtn:lang}/{gtn:sitename}/profile/{gtn:path}">
+    <route-param qname="gtn:handler">
+      <value>profile-access</value>
+    </route-param>
+    <route-param qname="gtn:sitetype">
+      <value>portal</value>
+    </route-param>
+    <path-param qname="gtn:lang" encoding="preserve-path">
+      <pattern>(ar|ar-AE|ar-BH|ar-DZ|ar-EG|ar-IQ|ar-JO|ar-KW|ar-LB|ar-LY|ar-MA|ar-OM|ar-QA|ar-SA|ar-SD|ar-SY|ar-TN|ar-YE|be|be-BY|bg|bg-BG|ca|ca-ES|co|co-FR|cs|cs-CZ|da|da-DK|de|de-AT|de-CH|de-DE|de-GR|de-LU|el|el-CY|el-GR|en|en-AU|en-CA|en-GB|en-IE|en-IN|en-MT|en-NZ|en-PH|en-SG|en-US|en-ZA|es|es-AR|es-BO|es-CL|es-CO|es-CR|es-CU|es-DO|es-EC|es-ES|es-GT|es-HN|es-MX|es-NI|es-PA|es-PE|es-PR|es-PY|es-SV|es-US|es-UY|es-VE|et|et-EE|fa|fi|fi-FI|fil|fr|fr-BE|fr-CA|fr-CH|fr-FR|fr-LU|ga|ga-IE|he|he-IL|hi|hi-IN|hr|hr-HR|hu|hu-HU|id|id-ID|is|is-IS|it|it-CH|it-IT|iw|iw-IL|ja|ja-JP|ja-JP-JP-#u-ca-japanese|ko|ko-KR|lt|lt-LT|lv|lv-LV|mk|mk-MK|ms|ms-MY|mt|mt-MT|nl|nl-BE|nl-NL|no|no-NO|no-NO-NY|pl|pl-PL|pt|pt-BR|pt-PT|ro|ro-RO|ru|ru-RU|sk|sk-SK|sl|sl-SI|sq|sq-AL|sr|sr-BA|sr-BA-#Latn|sr-CS|sr-ME|sr-ME-#Latn|sr-RS|sr-RS-#Latn|sr--#Latn|sv|sv-SE|th|th-TH|th-TH-TH-#u-nu-thai|tr|tr-TR|uk|uk-UA|vi|vi-VN|zh|zh-CN|zh-HK|zh-SG|zh-TW)?</pattern>
+    </path-param>
+    <path-param qname="gtn:path" encoding="preserve-path">
+      <pattern>.*</pattern>
+    </path-param>
+  </route>
+
   <route path="/">
     <!-- The portal handler -->
     <route-param qname="gtn:handler">


### PR DESCRIPTION
Routes the profile page requests through the new profile-access handler so that the profiles of not existing, disabled or deleted users end up on the page not found.