### PR TITLE
feat: Add the account deactivated page to the global site - EXO-89345

### DIFF
--- a/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/global_en.properties
@@ -64,6 +64,7 @@ portal.global.myteam=My Team
 portal.global.external-registration=Guest registration
 portal.global.login=Login
 portal.global.forgot-password=Forgot Password
+portal.global.account-deactivated=Account Deactivated
 portal.global.on-boarding=Create a password
 portal.global.restricted-project=Restricted Project
 portal.global.consent=Consent to app authorizations

--- a/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/global_fr.properties
+++ b/webapps/plf-sites-extension/src/main/resources/locale/navigation/portal/global_fr.properties
@@ -64,6 +64,7 @@ portal.global.myteam=Mon équipe
 portal.global.external-registration=Inscription d'un utilisateur externe
 portal.global.login=Se connecter
 portal.global.forgot-password=Mot de passe oublié
+portal.global.account-deactivated=Compte désactivé
 portal.global.on-boarding=Crée un mot de passe
 portal.global.restricted-project=Projet restreint
 portal.global.consent=Autorisations de l'application acceptées

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -367,6 +367,59 @@
       </init-params>
     </component-plugin>
     <component-plugin>
+      <name>AccountDeactivatedPageUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>global.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="updateNavigation">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="importMode">
+              <string>merge</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>account-deactivated</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
       <name>ContentEditorPageUpgradePlugin</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/navigation.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/navigation.xml
@@ -363,6 +363,12 @@
       <page-reference>portal::global::forgot-password</page-reference>
     </node>
     <node>
+      <name>account-deactivated</name>
+      <label>#{portal.global.account-deactivated}</label>
+      <visibility>SYSTEM</visibility>
+      <page-reference>portal::global::account-deactivated</page-reference>
+    </node>
+    <node>
       <name>on-boarding</name>
       <label>#{portal.global.on-boarding}</label>
       <visibility>SYSTEM</visibility>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -1392,6 +1392,123 @@
     </container>
   </page>
   <page>
+    <name>account-deactivated</name>
+    <title>Account Deactivated</title>
+    <access-permissions>Everyone</access-permissions>
+    <edit-permission>manager:/platform/administrators</edit-permission>
+    <show-max-window>true</show-max-window>
+    <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl" width="100%">
+      <css-style>
+        <margin-top>0</margin-top>
+        <margin-bottom>0</margin-bottom>
+        <margin-right>0</margin-right>
+        <margin-left>0</margin-left>
+        <background-color>#FFFFFF</background-color>
+      </css-style>
+      <section-columns cssClass="layout-sticky-application">
+        <column col-span="5">
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>SidebarLogin</portlet-ref>
+            </portlet>
+            <title>Sidebar Login</title>
+            <css-style>
+              <radius-top-right>0</radius-top-right>
+              <radius-top-left>0</radius-top-left>
+              <radius-bottom-right>0</radius-bottom-right>
+              <radius-bottom-left>0</radius-bottom-left>
+              <mobile-hidden>true</mobile-hidden>
+              <text-title-color>#FFFFFF</text-title-color>
+              <text-title-font-size>36px</text-title-font-size>
+              <text-title-font-weight>bold</text-title-font-weight>
+              <text-title-font-style>normal</text-title-font-style>
+              <text-header-color>#707070</text-header-color>
+              <text-header-font-size>18px</text-header-font-size>
+              <text-header-font-weight>normal</text-header-font-weight>
+              <text-header-font-style>normal</text-header-font-style>
+              <text-color>#FFFFFF</text-color>
+              <text-font-size>20px</text-font-size>
+              <text-font-weight>normal</text-font-weight>
+              <text-font-style>normal</text-font-style>
+              <text-subtitle-color>#707070</text-subtitle-color>
+              <text-subtitle-font-size>12px</text-subtitle-font-size>
+              <text-subtitle-font-weight>normal</text-subtitle-font-weight>
+              <text-subtitle-font-style>normal</text-subtitle-font-style>
+            </css-style>
+          </portlet-application>
+        </column>
+        <column col-span="7" cssClass="justify-space-between">
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>PlatformName</portlet-ref>
+            </portlet>
+            <title>Platform Name</title>
+            <height>150</height>
+            <css-style>
+              <margin-top>20</margin-top>
+              <margin-bottom>0</margin-bottom>
+              <margin-right>20</margin-right>
+              <margin-left>20</margin-left>
+              <text-title-color>#20282C</text-title-color>
+              <text-title-font-size>34px</text-title-font-size>
+              <text-title-font-weight>bold</text-title-font-weight>
+              <text-title-font-style>normal</text-title-font-style>
+              <text-header-color>#707070</text-header-color>
+              <text-header-font-size>18px</text-header-font-size>
+              <text-header-font-weight>normal</text-header-font-weight>
+              <text-header-font-style>normal</text-header-font-style>
+              <text-color>#20282C</text-color>
+              <text-font-size>16px</text-font-size>
+              <text-font-weight>normal</text-font-weight>
+              <text-font-style>normal</text-font-style>
+              <text-subtitle-color>#707070</text-subtitle-color>
+              <text-subtitle-font-size>12px</text-subtitle-font-size>
+              <text-subtitle-font-weight>normal</text-subtitle-font-weight>
+              <text-subtitle-font-style>normal</text-subtitle-font-style>
+
+            </css-style>
+          </portlet-application>
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>AccountDeactivated</portlet-ref>
+            </portlet>
+            <title>Account Deactivated</title>
+            <css-style>
+              <margin-top>-40</margin-top>
+              <margin-bottom>20</margin-bottom>
+              <margin-right>20</margin-right>
+              <margin-left>20</margin-left>
+            </css-style>
+          </portlet-application>
+          <portlet-application>
+            <portlet>
+              <application-ref>social</application-ref>
+              <portlet-ref>PlatformLogo</portlet-ref>
+              <preferences>
+                <preference>
+                  <name>hAlign</name>
+                  <value>END</value>
+                  <read-only>false</read-only>
+                </preference>
+              </preferences>
+            </portlet>
+            <title>Platform Logo</title>
+            <height>50</height>
+            <css-style>
+              <margin-top>20</margin-top>
+              <margin-bottom>40</margin-bottom>
+              <margin-right>20</margin-right>
+              <margin-left>0</margin-left>
+            </css-style>
+          </portlet-application>
+        </column>
+      </section-columns>
+    </container>
+  </page>
+  <page>
     <name>on-boarding</name>
     <title>Internal Registration</title>
     <access-permissions>Everyone</access-permissions>


### PR DESCRIPTION
A new "account-deactivated" page, following the login page layout and accessible to everyone, is added to the global site along with its navigation node, so administrators can customize it as any other page. An upgrade plugin imports the page and its navigation node on already running platforms.

Companion PRs: Meeds-io/portal#1309, Meeds-io/social#6003