### PR TITLE
feat: Rewrite the profile page layout EXO-89538

### DIFF
--- a/packaging/plf-assemblies/pom.xml
+++ b/packaging/plf-assemblies/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-packaging</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-assemblies</artifactId>
   <name>Meeds:: Meeds:: Meeds Public Distribution - Packaging - Assemblies</name>

--- a/packaging/plf-community-sources/pom.xml
+++ b/packaging/plf-community-sources/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-packaging</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-community-sources</artifactId>
   <packaging>pom</packaging>

--- a/packaging/plf-community-tomcat-standalone/pom.xml
+++ b/packaging/plf-community-tomcat-standalone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-packaging</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-community-tomcat-standalone</artifactId>
   <packaging>pom</packaging>

--- a/packaging/plf-dependencies/pom.xml
+++ b/packaging/plf-dependencies/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-packaging</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/packaging/plf-packaging-resources/pom.xml
+++ b/packaging/plf-packaging-resources/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-packaging</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-packaging-resources</artifactId>
   <packaging>pom</packaging>

--- a/packaging/plf-tomcat-resources/pom.xml
+++ b/packaging/plf-tomcat-resources/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-packaging</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-tomcat-resources</artifactId>
   <packaging>pom</packaging>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -22,7 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>meeds</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
 
   <name>Meeds:: Meeds:: Meeds Public Distribution - Packaging</name>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </parent>
   <groupId>io.meeds.distribution</groupId>
   <artifactId>meeds</artifactId>
-  <version>7.3.x-SNAPSHOT</version>
+  <version>7.3.x-devx-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Meeds:: Meeds:: Meeds Public Distribution</name>
   <modules>
@@ -49,55 +49,55 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- Dependencies Versions                    -->
     <!-- **************************************** -->
     <!-- The version of Platform To bundle -->
-    <io.meeds.social.version>7.3.x-SNAPSHOT</io.meeds.social.version>
-    <io.meeds.platform-ui.version>7.3.x-SNAPSHOT</io.meeds.platform-ui.version>
+    <io.meeds.social.version>7.3.x-devx-SNAPSHOT</io.meeds.social.version>
+    <io.meeds.platform-ui.version>7.3.x-devx-SNAPSHOT</io.meeds.platform-ui.version>
     <!-- The version of the add-ons manager -->
-    <io.meeds.platform.addons-manager.version>7.3.x-SNAPSHOT</io.meeds.platform.addons-manager.version>
+    <io.meeds.platform.addons-manager.version>7.3.x-devx-SNAPSHOT</io.meeds.platform.addons-manager.version>
     <!-- ************** -->
     <!-- Add-ons for Community packaging   -->
     <!-- ************** -->
     <addon.meeds.layout.id>meeds-layout</addon.meeds.layout.id>
-    <addon.meeds.layout.version>7.3.x-SNAPSHOT</addon.meeds.layout.version>
+    <addon.meeds.layout.version>7.3.x-devx-SNAPSHOT</addon.meeds.layout.version>
     <addon.meeds.kudos.id>meeds-kudos</addon.meeds.kudos.id>
-    <addon.meeds.kudos.version>7.3.x-SNAPSHOT</addon.meeds.kudos.version>
+    <addon.meeds.kudos.version>7.3.x-devx-SNAPSHOT</addon.meeds.kudos.version>
     <addon.meeds.perk-store.id>meeds-perk-store</addon.meeds.perk-store.id>
-    <addon.meeds.perk-store.version>7.3.x-SNAPSHOT</addon.meeds.perk-store.version>
+    <addon.meeds.perk-store.version>7.3.x-devx-SNAPSHOT</addon.meeds.perk-store.version>
     <addon.meeds.wallet.id>meeds-wallet</addon.meeds.wallet.id>
-    <addon.meeds.wallet.version>7.3.x-SNAPSHOT</addon.meeds.wallet.version>
+    <addon.meeds.wallet.version>7.3.x-devx-SNAPSHOT</addon.meeds.wallet.version>
     <addon.meeds.gamification.id>meeds-gamification</addon.meeds.gamification.id>
-    <addon.meeds.gamification.version>7.3.x-SNAPSHOT</addon.meeds.gamification.version>
+    <addon.meeds.gamification.version>7.3.x-devx-SNAPSHOT</addon.meeds.gamification.version>
     <addon.meeds.app-center.id>meeds-app-center</addon.meeds.app-center.id>
-    <addon.meeds.app-center.version>7.3.x-SNAPSHOT</addon.meeds.app-center.version>
+    <addon.meeds.app-center.version>7.3.x-devx-SNAPSHOT</addon.meeds.app-center.version>
     <addon.meeds.notes.id>meeds-notes</addon.meeds.notes.id>
-    <addon.meeds.notes.version>7.3.x-SNAPSHOT</addon.meeds.notes.version>
+    <addon.meeds.notes.version>7.3.x-devx-SNAPSHOT</addon.meeds.notes.version>
     <addon.meeds.tasks.id>meeds-tasks</addon.meeds.tasks.id>
-    <addon.meeds.tasks.version>7.3.x-SNAPSHOT</addon.meeds.tasks.version>
+    <addon.meeds.tasks.version>7.3.x-devx-SNAPSHOT</addon.meeds.tasks.version>
     <addon.meeds.analytics.id>meeds-analytics</addon.meeds.analytics.id>
-    <addon.meeds.analytics.version>7.3.x-SNAPSHOT</addon.meeds.analytics.version>
+    <addon.meeds.analytics.version>7.3.x-devx-SNAPSHOT</addon.meeds.analytics.version>
     <addon.meeds.poll.id>meeds-poll</addon.meeds.poll.id>
-    <addon.meeds.poll.version>7.3.x-SNAPSHOT</addon.meeds.poll.version>
+    <addon.meeds.poll.version>7.3.x-devx-SNAPSHOT</addon.meeds.poll.version>
     <addon.meeds.content.id>meeds-content</addon.meeds.content.id>
-    <addon.meeds.content.version>7.3.x-SNAPSHOT</addon.meeds.content.version>
+    <addon.meeds.content.version>7.3.x-devx-SNAPSHOT</addon.meeds.content.version>
     <addon.meeds.gamification-github.id>meeds-gamification-github</addon.meeds.gamification-github.id>
-    <addon.meeds.gamification-github.version>7.3.x-SNAPSHOT</addon.meeds.gamification-github.version>
+    <addon.meeds.gamification-github.version>7.3.x-devx-SNAPSHOT</addon.meeds.gamification-github.version>
     <addon.meeds.gamification-twitter.id>meeds-gamification-twitter</addon.meeds.gamification-twitter.id>
-    <addon.meeds.gamification-twitter.version>7.3.x-SNAPSHOT</addon.meeds.gamification-twitter.version>
+    <addon.meeds.gamification-twitter.version>7.3.x-devx-SNAPSHOT</addon.meeds.gamification-twitter.version>
     <addon.meeds.gamification-evm.id>meeds-gamification-evm</addon.meeds.gamification-evm.id>
-    <addon.meeds.gamification-evm.version>7.3.x-SNAPSHOT</addon.meeds.gamification-evm.version>
+    <addon.meeds.gamification-evm.version>7.3.x-devx-SNAPSHOT</addon.meeds.gamification-evm.version>
     <addon.meeds.deeds-tenant.id>meeds-deeds-tenant</addon.meeds.deeds-tenant.id>
-    <addon.meeds.deeds-tenant.version>7.3.x-SNAPSHOT</addon.meeds.deeds-tenant.version>
+    <addon.meeds.deeds-tenant.version>7.3.x-devx-SNAPSHOT</addon.meeds.deeds-tenant.version>
     <addon.meeds.gamification-crowdin.id>meeds-gamification-crowdin</addon.meeds.gamification-crowdin.id>
-    <addon.meeds.gamification-crowdin.version>7.3.x-SNAPSHOT</addon.meeds.gamification-crowdin.version>
+    <addon.meeds.gamification-crowdin.version>7.3.x-devx-SNAPSHOT</addon.meeds.gamification-crowdin.version>
     <addon.meeds.pwa.id>meeds-pwa</addon.meeds.pwa.id>
-    <addon.meeds.pwa.version>7.3.x-SNAPSHOT</addon.meeds.pwa.version>
+    <addon.meeds.pwa.version>7.3.x-devx-SNAPSHOT</addon.meeds.pwa.version>
     <addon.meeds.ide.id>meeds-ide</addon.meeds.ide.id>
-    <addon.meeds.ide.version>7.3.x-SNAPSHOT</addon.meeds.ide.version>
+    <addon.meeds.ide.version>7.3.x-devx-SNAPSHOT</addon.meeds.ide.version>
     <addon.meeds.auth-server.id>meeds-auth-server</addon.meeds.auth-server.id>
-    <addon.meeds.auth-server.version>7.3.x-SNAPSHOT</addon.meeds.auth-server.version>
+    <addon.meeds.auth-server.version>7.3.x-devx-SNAPSHOT</addon.meeds.auth-server.version>
     <addon.meeds.mcp-server.id>meeds-mcp-server</addon.meeds.mcp-server.id>
-    <addon.meeds.mcp-server.version>7.3.x-SNAPSHOT</addon.meeds.mcp-server.version>
+    <addon.meeds.mcp-server.version>7.3.x-devx-SNAPSHOT</addon.meeds.mcp-server.version>
     <addon.meeds.matrix.id>meeds-matrix</addon.meeds.matrix.id>
-    <addon.meeds.matrix.version>7.3.x-SNAPSHOT</addon.meeds.matrix.version>
+    <addon.meeds.matrix.version>7.3.x-devx-SNAPSHOT</addon.meeds.matrix.version>
     <!-- Add-on manager extension to use (empty for Unix, .bat for Windows) -->
     <addon.manager.extension />
 

--- a/services/plf-community-edition-service/pom.xml
+++ b/services/plf-community-edition-service/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-services</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-community-edition-service</artifactId>
   <packaging>jar</packaging>

--- a/services/plf-configuration/pom.xml
+++ b/services/plf-configuration/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-services</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-configuration</artifactId>
   <packaging>jar</packaging>

--- a/services/plf-tomcat-pc-creator-listener/pom.xml
+++ b/services/plf-tomcat-pc-creator-listener/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-services</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-tomcat-pc-creator-listener</artifactId>
   <packaging>jar</packaging>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -22,7 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>meeds</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
 
   <name>Meeds:: Meeds:: Meeds Public Distribution - Services</name>

--- a/webapps/plf-meeds-extension/pom.xml
+++ b/webapps/plf-meeds-extension/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-webapps</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-meeds-extension</artifactId>
   <packaging>war</packaging>

--- a/webapps/plf-root-webapp/pom.xml
+++ b/webapps/plf-root-webapp/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-webapps</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-root-webapp</artifactId>
   <packaging>war</packaging>

--- a/webapps/plf-sites-extension/pom.xml
+++ b/webapps/plf-sites-extension/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-webapps</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-sites-extension</artifactId>
   <packaging>war</packaging>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -46,13 +46,21 @@
         </value-param>
         <object-param>
           <name>profile.upgrade</name>
-          <!-- eXIP 7.3.0.18 (EXO-89538): re-imports the profile page so the user
-               spaces listing replaces the removed activity card and the dynamic
-               containers are gone. A page re-import REPLACES the whole stored
-               definition with the shipped one: every administrator customization
-               of the profile page is lost, there is no page version history, and
-               this is the accepted, documented behaviour of this upgrade — see
-               the release note and the migration procedure. -->
+          <!-- eXIP "User spaces list on the profile page" (Tribe note 50524,
+               EXO-89538): re-imports the profile page so the user spaces listing
+               replaces the removed activity card and the dynamic containers are
+               gone. A page re-import REPLACES the whole stored definition with
+               the shipped one: every administrator customization of the profile
+               page is lost, there is no page version history, and this is the
+               accepted, documented behaviour of this upgrade — see the release
+               note and the migration procedure.
+               The profiles="..." cells of the page are filtered when the page is
+               imported (Container.buildChildren() drops a portlet-application
+               whose profile is inactive before the page is stored), not when it
+               is rendered. This plugin runs once, so an addon among analytics,
+               kudos and gamification installed AFTER this upgrade does not
+               appear on the profile page until the page is restored from the
+               layout editor, which re-applies the shipped layout. -->
           <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
             <field name="updatePageLayout">
               <boolean>true</boolean>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -24,6 +24,60 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
+      <name>ProfilePageLayoutUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>160</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>profile.upgrade</name>
+          <!-- eXIP 7.3.0.18 (EXO-89538): re-imports the profile page so the user
+               spaces listing replaces the removed activity card and the dynamic
+               containers are gone. A page re-import REPLACES the whole stored
+               definition with the shipped one: every administrator customization
+               of the profile page is lost, there is no page version history, and
+               this is the accepted, documented behaviour of this upgrade — see
+               the release note and the migration procedure. -->
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>profile</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
       <name>OverviewPageLayoutUpgrade</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -277,10 +277,6 @@
         sticky-beahvior="true"
         mobile-columns-style="true">
         <column col-span="8">
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-before-about-me-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
@@ -288,14 +284,6 @@
             </portlet>
             <title>Profile AboutMe Portlet</title>
           </portlet-application>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-after-about-me-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-before-contact-information-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
@@ -303,14 +291,6 @@
             </portlet>
             <title>Profile contact information Portlet</title>
           </portlet-application>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-after-contact-information-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-before-work-experience-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
@@ -318,16 +298,36 @@
             </portlet>
             <title>Profile Work Experience Portlet</title>
           </portlet-application>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-after-work-experience-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
         </column>
         <column col-span="4">
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-right-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
+          <portlet-application profiles="analytics">
+            <portlet>
+              <application-ref>analytics</application-ref>
+              <portlet-ref>SpacesListWidget</portlet-ref>
+            </portlet>
+            <title>User Spaces List</title>
+          </portlet-application>
+          <portlet-application profiles="kudos">
+            <portlet>
+              <application-ref>kudos</application-ref>
+              <portlet-ref>KudosOverview</portlet-ref>
+            </portlet>
+            <title>Kudos Overview</title>
+          </portlet-application>
+          <portlet-application profiles="gamification">
+            <portlet>
+              <application-ref>gamification-portlets</application-ref>
+              <portlet-ref>BadgesOverview</portlet-ref>
+            </portlet>
+            <title>Badges Overview</title>
+          </portlet-application>
+          <portlet-application profiles="gamification">
+            <portlet>
+              <application-ref>gamification-portlets</application-ref>
+              <portlet-ref>ConnectorUserProfile</portlet-ref>
+            </portlet>
+            <title>Connector User Profile</title>
+          </portlet-application>
         </column>
       </section-columns>
     </container>

--- a/webapps/plf-tomcat-integration-webapp/pom.xml
+++ b/webapps/plf-tomcat-integration-webapp/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>plf-webapps</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
   <artifactId>plf-tomcat-integration-webapp</artifactId>
   <packaging>war</packaging>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -22,7 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <parent>
     <groupId>io.meeds.distribution</groupId>
     <artifactId>meeds</artifactId>
-    <version>7.3.x-SNAPSHOT</version>
+    <version>7.3.x-devx-SNAPSHOT</version>
   </parent>
 
   <name>Meeds:: Meeds:: Meeds Public Distribution - Webapps</name>


### PR DESCRIPTION
Prior to this change, the profile page's right column was filled through the `profile-right-container` and six `profile-before/after-*` dynamic containers, so its real composition was hidden and contributed by each addon from outside the page. This change declares the right-column portlets directly in the page definition, each guarded by its addon's profile, with the user spaces listing replacing the activity card, and re-imports the page once on existing instances through a `LayoutUpgradePlugin`.
