### PR TITLE
feat: Rewrite the profile page layout - EXO-89538

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -46,13 +46,21 @@
         </value-param>
         <object-param>
           <name>profile.upgrade</name>
-          <!-- eXIP 7.3.0.18 (EXO-89538): re-imports the profile page so the user
-               spaces listing replaces the removed activity card and the dynamic
-               containers are gone. A page re-import REPLACES the whole stored
-               definition with the shipped one: every administrator customization
-               of the profile page is lost, there is no page version history, and
-               this is the accepted, documented behaviour of this upgrade — see
-               the release note and the migration procedure. -->
+          <!-- eXIP "User spaces list on the profile page" (Tribe note 50524,
+               EXO-89538): re-imports the profile page so the user spaces listing
+               replaces the removed activity card and the dynamic containers are
+               gone. A page re-import REPLACES the whole stored definition with
+               the shipped one: every administrator customization of the profile
+               page is lost, there is no page version history, and this is the
+               accepted, documented behaviour of this upgrade — see the release
+               note and the migration procedure.
+               The profiles="..." cells of the page are filtered when the page is
+               imported (Container.buildChildren() drops a portlet-application
+               whose profile is inactive before the page is stored), not when it
+               is rendered. This plugin runs once, so an addon among analytics,
+               kudos and gamification installed AFTER this upgrade does not
+               appear on the profile page until the page is restored from the
+               layout editor, which re-applies the shipped layout. -->
           <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
             <field name="updatePageLayout">
               <boolean>true</boolean>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -24,6 +24,60 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
+      <name>ProfilePageLayoutUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>160</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>profile.upgrade</name>
+          <!-- eXIP 7.3.0.18 (EXO-89538): re-imports the profile page so the user
+               spaces listing replaces the removed activity card and the dynamic
+               containers are gone. A page re-import REPLACES the whole stored
+               definition with the shipped one: every administrator customization
+               of the profile page is lost, there is no page version history, and
+               this is the accepted, documented behaviour of this upgrade — see
+               the release note and the migration procedure. -->
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>profile</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
       <name>OverviewPageLayoutUpgrade</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -277,10 +277,6 @@
         sticky-beahvior="true"
         mobile-columns-style="true">
         <column col-span="8">
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-before-about-me-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
@@ -288,14 +284,6 @@
             </portlet>
             <title>Profile AboutMe Portlet</title>
           </portlet-application>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-after-about-me-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-before-contact-information-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
@@ -303,14 +291,6 @@
             </portlet>
             <title>Profile contact information Portlet</title>
           </portlet-application>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-after-contact-information-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-before-work-experience-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
@@ -318,16 +298,36 @@
             </portlet>
             <title>Profile Work Experience Portlet</title>
           </portlet-application>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-after-work-experience-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
         </column>
         <column col-span="4">
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-right-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
+          <portlet-application profiles="analytics">
+            <portlet>
+              <application-ref>analytics</application-ref>
+              <portlet-ref>SpacesListWidget</portlet-ref>
+            </portlet>
+            <title>User Spaces List</title>
+          </portlet-application>
+          <portlet-application profiles="kudos">
+            <portlet>
+              <application-ref>kudos</application-ref>
+              <portlet-ref>KudosOverview</portlet-ref>
+            </portlet>
+            <title>Kudos Overview</title>
+          </portlet-application>
+          <portlet-application profiles="gamification">
+            <portlet>
+              <application-ref>gamification-portlets</application-ref>
+              <portlet-ref>BadgesOverview</portlet-ref>
+            </portlet>
+            <title>Badges Overview</title>
+          </portlet-application>
+          <portlet-application profiles="gamification">
+            <portlet>
+              <application-ref>gamification-portlets</application-ref>
+              <portlet-ref>ConnectorUserProfile</portlet-ref>
+            </portlet>
+            <title>Connector User Profile</title>
+          </portlet-application>
         </column>
       </section-columns>
     </container>


### PR DESCRIPTION
Prior to this change, the profile page's right column was filled through the profile-right-container and six profile-before/after-* dynamic containers, so its real composition was hidden and contributed by each addon from outside the page. This change declares the right-column portlets directly in the page definition, each guarded by its addon's profile, with the user spaces listing replacing the activity card, and re-imports the page once on existing instances through a LayoutUpgradePlugin