### PR TITLE
feat: Rewrite the profile page layout - EXO-89538

### DIFF
--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal-upgrade-configuration.xml
@@ -24,6 +24,68 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
+      <name>ProfilePageLayoutUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>160</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>profile.upgrade</name>
+          <!-- eXIP "User spaces list on the profile page" (Tribe note 50524,
+               EXO-89538): re-imports the profile page so the user spaces listing
+               replaces the removed activity card and the dynamic containers are
+               gone. A page re-import REPLACES the whole stored definition with
+               the shipped one: every administrator customization of the profile
+               page is lost, there is no page version history, and this is the
+               accepted, documented behaviour of this upgrade — see the release
+               note and the migration procedure.
+               The profiles="..." cells of the page are filtered when the page is
+               imported (Container.buildChildren() drops a portlet-application
+               whose profile is inactive before the page is stored), not when it
+               is rendered. This plugin runs once, so an addon among analytics,
+               kudos and gamification installed AFTER this upgrade does not
+               appear on the profile page until the page is restored from the
+               layout editor, which re-applies the shipped layout. -->
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/sites/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>profile</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
       <name>OverviewPageLayoutUpgrade</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>

--- a/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
+++ b/webapps/plf-sites-extension/src/main/webapp/WEB-INF/conf/sites/portal/global/pages.xml
@@ -277,10 +277,6 @@
         sticky-beahvior="true"
         mobile-columns-style="true">
         <column col-span="8">
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-before-about-me-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
@@ -288,14 +284,6 @@
             </portlet>
             <title>Profile AboutMe Portlet</title>
           </portlet-application>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-after-about-me-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-before-contact-information-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
@@ -303,14 +291,6 @@
             </portlet>
             <title>Profile contact information Portlet</title>
           </portlet-application>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-after-contact-information-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-before-work-experience-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
           <portlet-application>
             <portlet>
               <application-ref>social</application-ref>
@@ -318,16 +298,36 @@
             </portlet>
             <title>Profile Work Experience Portlet</title>
           </portlet-application>
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-after-work-experience-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
         </column>
         <column col-span="4">
-          <container template="system:/groovy/portal/webui/container/UIAddOnColumnContainer.gtmpl">
-            <name>profile-right-container</name>
-            <factory-id>addonContainer</factory-id>
-          </container>
+          <portlet-application profiles="analytics">
+            <portlet>
+              <application-ref>analytics</application-ref>
+              <portlet-ref>SpacesListWidget</portlet-ref>
+            </portlet>
+            <title>User Spaces List</title>
+          </portlet-application>
+          <portlet-application profiles="kudos">
+            <portlet>
+              <application-ref>kudos</application-ref>
+              <portlet-ref>KudosOverview</portlet-ref>
+            </portlet>
+            <title>Kudos Overview</title>
+          </portlet-application>
+          <portlet-application profiles="gamification">
+            <portlet>
+              <application-ref>gamification-portlets</application-ref>
+              <portlet-ref>BadgesOverview</portlet-ref>
+            </portlet>
+            <title>Badges Overview</title>
+          </portlet-application>
+          <portlet-application profiles="gamification">
+            <portlet>
+              <application-ref>gamification-portlets</application-ref>
+              <portlet-ref>ConnectorUserProfile</portlet-ref>
+            </portlet>
+            <title>Connector User Profile</title>
+          </portlet-application>
         </column>
       </section-columns>
     </container>


### PR DESCRIPTION
Prior to this change, the profile page's right column was filled through `profile-right-container` and six `profile-before/after-*` dynamic containers, so its real composition was hidden and contributed by each addon from outside the page.
This change declares the right-column portlets directly in the page definition, each guarded by its addon's profile (`analytics`, `kudos`, `gamification`), with the user spaces listing replacing the activity card, and re-imports the page once on existing instances through a `LayoutUpgradePlugin` (`ProfilePageLayoutUpgrade`, execution order 160, `execute.once=true`).

Part of eXIP 7.3.0.18 "User Spaces List" (Tribe note 50524), released **last**, after Meeds-io/social#6085, Meeds-io/analytics#446, Meeds-io/gamification#2002 and Meeds-io/kudos#628 — merging it before the two addon PRs would briefly leave the profile page with both the page-level declaration and the dynamic-container one.

### What the page carries after the upgrade (board story US08)
`analytics/SpacesListWidget` ("User Spaces List", `profiles="analytics"`), `kudos/KudosOverview` (`profiles="kudos"`), `gamification-portlets/BadgesOverview` and `gamification-portlets/ConnectorUserProfile` (`profiles="gamification"`). `gamification-portlets/ProfileStats` (the "My activity" card: connections, weekly points, weekly rank, pending requests, gamification ranking) leaves the profile page and is re-declared nowhere; it stays registered in the application registry.

### Release note — to be carried into the customer release note and the migration procedure
1. **The profile page is re-imported and returns to its shipped state.** A page re-import is a full replacement, not a merge (`PageImporter` treats `MERGE` like `OVERWRITE`): **every administrator customization of the profile page is lost** — portlets added, moved, or placed inside any of the dropped containers. There is no page version history to roll back to, and the layout editor's own "restore" performs the same replacement. The only mitigation is to identify the instances that customized the profile page **before** upgrading and capture their layout, then re-apply it by hand in the layout editor afterwards. The PO has accepted the reset as expected behaviour (US08).
2. **Seven `addonContainer` names are removed** from the profile page; a customer extension contributing to any of them must be adapted (a deployed instance is known to declare `wallet/WalletOverview` in one): `profile-right-container`, `profile-before-about-me-container`, `profile-after-about-me-container`, `profile-before-contact-information-container`, `profile-after-contact-information-container`, `profile-before-work-experience-container`, `profile-after-work-experience-container`.
3. **Late install of an addon.** The `profiles="..."` cells are filtered when the page is imported (`Container.buildChildren()` drops a cell whose profile is inactive before the page is stored), not when it is rendered, and this plugin runs once. An instance upgraded **without** analytics, kudos or gamification installed will not show that addon's block on the profile page when the addon is installed later; recovery is a "restore" of the profile page from the layout editor, which re-applies the shipped layout — at the cost described in point 1.
4. The "My activity" card is removed with what it contained (connections, weekly points and rank, pending requests, gamification ranking); where weekly points and rank resurface, if anywhere, is PO deferred item 3.

Knowledge: Meeds-io/eng-standards#30, Meeds-io/eng-standards#31 (merged) — the `profiles` page pattern and the MERGE-is-OVERWRITE re-import; the late-install caveat (point 3) is added to `frontend-vue.md` by the knowledge PR referenced from Meeds-io/social#6085.

Classification: N1 for the delivery as a whole, and this PR contributes a socle trigger of its own — an upgrade plugin that irreversibly rewrites a shipped page layout. Architect/Senior Developer validation, author ≠ approver, no auto-merge on AI review alone.
